### PR TITLE
Release readiness polish: effects toggle, drops preview

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,6 +17,8 @@ branches the sender can't run.
 | `/mythicrod rod select <tier>` | Switch your own rod tier (`basic`, `advanced`, `legendary`) | `mythicrod.gui` (+ `.rod.advanced` / `.legendary`) |
 | `/mythicrod rod inspect` | Dump PDC for the held rod | `mythicrod.admin.debug` |
 | `/mythicrod drops [category]` | Drop browser, category view | `mythicrod.drops.view` |
+| `/mythicrod drops preview <biome>` | Eligible drops + weight share for a biome | `mythicrod.admin.debug` |
+| `/mythicrod effects [mode]` | Toggle or set visual effects (`normal`/`reduced`) for yourself | `mythicrod.gui` |
 | `/mythicrod drop add <category> <identifier> <weight> <amount>` | Add drop and persist to `drops.yml` | `mythicrod.admin.config` |
 | `/mythicrod drop remove <category> <identifier>` | Delete drop and persist | `mythicrod.admin.config` |
 | `/mythicrod drop set <category> <identifier> <field> <value>` | Update one of `weight`, `amount`, `name`, `permission`, `glow` | `mythicrod.admin.config` |

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
@@ -1,6 +1,7 @@
 package io.xcutiboo.mythicrod.paper.commands;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -133,6 +134,12 @@ public class BrigadierCommandManager {
                 .then(Commands.literal("inspect")
                     .requires(source -> source.getSender().hasPermission(PermissionNodes.ADMIN_DEBUG))
                     .executes(this::executeRodInspect)))
+            .then(Commands.literal("effects")
+                .requires(source -> source.getSender().hasPermission(PermissionNodes.GUI))
+                .executes(this::executeEffectsToggle)
+                .then(Commands.argument("mode", StringArgumentType.word())
+                    .suggests(this::suggestEffectModes)
+                    .executes(this::executeEffectsSet)))
             .then(Commands.literal("reload")
                 .requires(source -> source.getSender().hasPermission(PermissionNodes.ADMIN_RELOAD))
                 .executes(this::executeReload))
@@ -166,6 +173,11 @@ public class BrigadierCommandManager {
             .then(Commands.literal(KEY_DROPS)
                 .requires(source -> source.getSender().hasPermission(PermissionNodes.DROPS_VIEW))
                 .executes(this::executeDrops)
+                .then(Commands.literal("preview")
+                    .requires(source -> source.getSender().hasPermission(PermissionNodes.ADMIN_DEBUG))
+                    .then(Commands.argument("biome", StringArgumentType.string())
+                        .suggests(this::suggestBiomes)
+                        .executes(this::executeDropsPreview)))
                 .then(Commands.argument(KEY_CATEGORY, StringArgumentType.word())
                     .suggests(this::suggestDropCategories)
                     .executes(this::executeDropsCategory)))
@@ -1832,6 +1844,127 @@ public class BrigadierCommandManager {
         }
         return builder.buildFuture();
     }
+
+    private CompletableFuture<Suggestions> suggestEffectModes(
+        @SuppressWarnings("unused") CommandContext<CommandSourceStack> context,
+        SuggestionsBuilder builder
+    ) {
+        for (String m : List.of("normal", "reduced")) {
+            builder.suggest(m);
+        }
+        return builder.buildFuture();
+    }
+
+    private int executeEffectsToggle(CommandContext<CommandSourceStack> context) {
+        CommandSender sender = context.getSource().getSender();
+        if (!(sender instanceof Player player)) {
+            sendMessage(sender, tr(sender, TR_PLAYER_ONLY));
+            playErrorSound(sender);
+            return 0;
+        }
+        plugin.getPlayerDataService().toggleReducedEffects(player);
+        boolean reduced = plugin.getPlayerDataService().hasReducedEffects(player);
+        sendMessage(sender, tr(sender, reduced
+            ? "command.effects.set-reduced"
+            : "command.effects.set-normal"));
+        playSuccessSound(sender);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private int executeEffectsSet(CommandContext<CommandSourceStack> context) {
+        CommandSender sender = context.getSource().getSender();
+        if (!(sender instanceof Player player)) {
+            sendMessage(sender, tr(sender, TR_PLAYER_ONLY));
+            playErrorSound(sender);
+            return 0;
+        }
+        String mode = StringArgumentType.getString(context, "mode").toLowerCase(Locale.ROOT);
+        boolean reduced;
+        switch (mode) {
+            case "reduced" -> reduced = true;
+            case "normal", "full" -> reduced = false;
+            default -> {
+                sendMessage(sender, tr(sender, "command.effects.invalid",
+                    Map.of("mode", mode)));
+                playErrorSound(sender);
+                return 0;
+            }
+        }
+        plugin.getPlayerDataService().setReducedEffects(player, reduced);
+        sendMessage(sender, tr(sender, reduced
+            ? "command.effects.set-reduced"
+            : "command.effects.set-normal"));
+        playSuccessSound(sender);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private int executeDropsPreview(CommandContext<CommandSourceStack> context) {
+        CommandSender sender = context.getSource().getSender();
+        try {
+            String biome = StringArgumentType.getString(context, "biome").trim();
+            NamespacedKey biomeKey = parseRegistryKey(biome);
+            if (biomeKey == null
+                    || RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME).get(biomeKey) == null) {
+                sendMessage(sender, tr(sender, "command.drops-preview.invalid-biome",
+                    Map.of("biome", biome)));
+                playErrorSound(sender);
+                return 0;
+            }
+            String biomeId = biomeKey.asString();
+
+            sendMessage(sender, tr(sender, "command.drops-preview.header",
+                Map.of("biome", biomeId)));
+
+            int rows = 0;
+            long totalWeight = 0L;
+            List<EligibleDrop> eligible = new ArrayList<>();
+            Map<String, List<CustomDrop>> categories = plugin.getDropManager().getDropCategories();
+            for (Map.Entry<String, List<CustomDrop>> entry : categories.entrySet()) {
+                for (CustomDrop drop : entry.getValue()) {
+                    List<String> biomes = drop.getBiomes();
+                    if (biomes != null && !biomes.isEmpty() && !biomes.contains(biomeId)) {
+                        continue;
+                    }
+                    eligible.add(new EligibleDrop(entry.getKey(), drop));
+                    totalWeight += Math.max(0, drop.getWeight());
+                }
+            }
+            eligible.sort(Comparator.comparingInt((EligibleDrop e) -> e.drop().getWeight()).reversed());
+
+            for (EligibleDrop entry : eligible) {
+                if (rows++ >= 12) {
+                    sendMessage(sender, tr(sender, "command.drops-preview.truncated",
+                        Map.of("count", String.valueOf(eligible.size() - 12))));
+                    break;
+                }
+                double share = totalWeight == 0 ? 0.0 : (entry.drop().getWeight() * 100.0 / totalWeight);
+                sendMessage(sender, tr(sender, "command.drops-preview.row",
+                    Map.of(
+                        "category", entry.category(),
+                        "identifier", entry.drop().getIdentifier(),
+                        "weight", String.valueOf(entry.drop().getWeight()),
+                        "share", String.format(Locale.ROOT, "%.1f", share)
+                    )));
+            }
+            if (eligible.isEmpty()) {
+                sendMessage(sender, tr(sender, "command.drops-preview.empty"));
+            } else {
+                sendMessage(sender, tr(sender, "command.drops-preview.footer",
+                    Map.of(
+                        "count", String.valueOf(eligible.size()),
+                        "weight", String.valueOf(totalWeight))));
+            }
+            playSuccessSound(sender);
+            return Command.SINGLE_SUCCESS;
+        } catch (RuntimeException e) {
+            sendMessage(sender, tr(sender, TR_GENERAL_ERROR));
+            playErrorSound(sender);
+            plugin.getLogger().log(Level.SEVERE, "Error executing drops preview", e);
+            return 0;
+        }
+    }
+
+    private record EligibleDrop(String category, CustomDrop drop) {}
 
     private int executeStatus(CommandContext<CommandSourceStack> context) {
         CommandSender sender = context.getSource().getSender();

--- a/mythicrod-paper/src/main/resources/lang/en_GB.yml
+++ b/mythicrod-paper/src/main/resources/lang/en_GB.yml
@@ -41,6 +41,10 @@ command:
   gui:
     opened: '<green>✓ <gray>Main GUI opened.'
     opened-hint: '<dark_gray>tip: <yellow>/mythicrod help<dark_gray> lists every command available to you.'
+  effects:
+    set-normal: '<green>✓ <gray>Visual effects set to <white>normal<gray>.'
+    set-reduced: '<green>✓ <gray>Visual effects set to <white>reduced<gray>.'
+    invalid: '<red>✗ <dark_red>Unknown mode <yellow>%mode%<dark_red>. Use <yellow>normal<dark_red> or <yellow>reduced<dark_red>.'
   rod:
     opened: '<green>✓ <gray>Rod settings opened.'
     selected: '<green>✓ <gray>Rod tier set to <white>%tier%<gray>.'
@@ -72,6 +76,13 @@ command:
     bubble-set: '<green>✓ <gray>Bubble particle set to <white>%type%</white><gray>.'
     success-set: '<green>✓ <gray>Success particle set to <white>%type%</white><gray>.'
     xp-set: '<green>✓ <gray>XP particle set to <white>%type%</white><gray>.'
+  drops-preview:
+    header: '<gold><bold>=== Drops eligible in <yellow>%biome%</yellow> ===</bold></gold>'
+    row: '<dark_gray>  • <gray>%category%<dark_gray>/<white>%identifier%</white> <dark_gray>(weight <yellow>%weight%</yellow>, ~<yellow>%share%%</yellow>)'
+    footer: '<gray>  Total: <white>%count%</white> drops, summed weight <white>%weight%</white>.'
+    truncated: '<dark_gray>  ... and <yellow>%count%</yellow> more (truncated).'
+    empty: '<yellow>⚠ <gray>No drops are eligible for this biome.'
+    invalid-biome: '<red>✗ <dark_red>Unknown biome <yellow>%biome%<dark_red>.'
   status:
     header: '<gold><bold>=== MythicRod Status ===</bold></gold>'
     version: '<gray>Plugin: <white>%version%'

--- a/mythicrod-paper/src/main/resources/lang/en_US.yml
+++ b/mythicrod-paper/src/main/resources/lang/en_US.yml
@@ -41,6 +41,10 @@ command:
   gui:
     opened: '<green>✓ <gray>Main GUI opened.'
     opened-hint: '<dark_gray>tip: <yellow>/mythicrod help<dark_gray> lists every command available to you.'
+  effects:
+    set-normal: '<green>✓ <gray>Visual effects set to <white>normal<gray>.'
+    set-reduced: '<green>✓ <gray>Visual effects set to <white>reduced<gray>.'
+    invalid: '<red>✗ <dark_red>Unknown mode <yellow>%mode%<dark_red>. Use <yellow>normal<dark_red> or <yellow>reduced<dark_red>.'
   rod:
     opened: '<green>✓ <gray>Rod settings opened.'
     selected: '<green>✓ <gray>Rod tier set to <white>%tier%<gray>.'
@@ -72,6 +76,13 @@ command:
     bubble-set: '<green>✓ <gray>Bubble particle set to <white>%type%</white><gray>.'
     success-set: '<green>✓ <gray>Success particle set to <white>%type%</white><gray>.'
     xp-set: '<green>✓ <gray>XP particle set to <white>%type%</white><gray>.'
+  drops-preview:
+    header: '<gold><bold>=== Drops eligible in <yellow>%biome%</yellow> ===</bold></gold>'
+    row: '<dark_gray>  • <gray>%category%<dark_gray>/<white>%identifier%</white> <dark_gray>(weight <yellow>%weight%</yellow>, ~<yellow>%share%%</yellow>)'
+    footer: '<gray>  Total: <white>%count%</white> drops, summed weight <white>%weight%</white>.'
+    truncated: '<dark_gray>  ... and <yellow>%count%</yellow> more (truncated).'
+    empty: '<yellow>⚠ <gray>No drops are eligible for this biome.'
+    invalid-biome: '<red>✗ <dark_red>Unknown biome <yellow>%biome%<dark_red>.'
   status:
     header: '<gold><bold>=== MythicRod Status ===</bold></gold>'
     version: '<gray>Plugin: <white>%version%'

--- a/mythicrod-paper/src/main/resources/lang/ja_JP.yml
+++ b/mythicrod-paper/src/main/resources/lang/ja_JP.yml
@@ -41,6 +41,10 @@ command:
   gui:
     opened: '<green>✓ <gray>メインGUIを開きました。'
     opened-hint: '<dark_gray>ヒント: <yellow>/mythicrod help<dark_gray> で使用可能なコマンド一覧を表示できます。'
+  effects:
+    set-normal: '<green>✓ <gray>視覚エフェクトを <white>通常<gray> に設定しました。'
+    set-reduced: '<green>✓ <gray>視覚エフェクトを <white>控えめ<gray> に設定しました。'
+    invalid: '<red>✗ <dark_red>不明なモード <yellow>%mode%<dark_red>。<yellow>normal<dark_red> または <yellow>reduced<dark_red> を使用してください。'
   rod:
     opened: '<green>✓ <gray>ロッド設定を開きました。'
     selected: '<green>✓ <gray>ロッド階級を <white>%tier%<gray> に設定しました。'
@@ -72,6 +76,13 @@ command:
     bubble-set: '<green>✓ <gray>バブルパーティクルを <white>%type%</white><gray> に設定しました。'
     success-set: '<green>✓ <gray>成功パーティクルを <white>%type%</white><gray> に設定しました。'
     xp-set: '<green>✓ <gray>XP パーティクルを <white>%type%</white><gray> に設定しました。'
+  drops-preview:
+    header: '<gold><bold>=== <yellow>%biome%</yellow> で出現可能なドロップ ===</bold></gold>'
+    row: '<dark_gray>  • <gray>%category%<dark_gray>/<white>%identifier%</white> <dark_gray>(重み <yellow>%weight%</yellow>、約 <yellow>%share%%</yellow>)'
+    footer: '<gray>  合計: <white>%count%</white> 件 / 重み合計 <white>%weight%</white>。'
+    truncated: '<dark_gray>  ... さらに <yellow>%count%</yellow> 件（省略）。'
+    empty: '<yellow>⚠ <gray>このバイオームで該当するドロップはありません。'
+    invalid-biome: '<red>✗ <dark_red>未知のバイオーム <yellow>%biome%<dark_red>。'
   status:
     header: '<gold><bold>=== MythicRod ステータス ===</bold></gold>'
     version: '<gray>プラグイン: <white>%version%'


### PR DESCRIPTION
## Summary
- /mythicrod effects: per-player chat toggle that mirrors the GUI rod menu visual-effects tile. Writes through PlayerDataService.
- /mythicrod drops preview <biome>: admin tool listing eligible drops for a biome, sorted by weight, with rough share of the weight pool. Validates the biome key against the Paper registry.

Both commands are wired with Brigadier suggestions, gated by the existing permission nodes, and have lang keys for en_US, en_GB, and ja_JP.

## Test plan
- [x] ./gradlew clean build (28 tasks, success)
- [x] ./gradlew test (114 tests, 0 failures)
- [x] BundledLocaleParityTest still green after adding the new keys
- [ ] Manual /mythicrod effects toggle on Paper server
- [ ] Manual /mythicrod drops preview minecraft:ocean on Paper server

## Summary by Sourcery

Add player-facing commands to control visual effects and preview biome-specific drops, with corresponding localisation and documentation updates.

New Features:
- Introduce `/mythicrod effects` command to toggle or explicitly set a player's visual effects mode between normal and reduced.
- Add `/mythicrod drops preview <biome>` admin command to list eligible drops for a biome along with their relative weight share.

Enhancements:
- Wire new commands with Brigadier suggestions and integrate them with existing permission nodes and player data handling.

Documentation:
- Document the new `/mythicrod drops preview` and `/mythicrod effects` commands in the commands reference.