### PR TITLE
Live test fixes: en_GB bundled load, drops preview parsing, VINE material

### DIFF
--- a/mythicrod-common/src/main/resources/drops.yml
+++ b/mythicrod-common/src/main/resources/drops.yml
@@ -152,7 +152,7 @@ drops:
     - 'TROPICAL_FISH,25,1'
     - 'FEATHER,20,2'
     - 'MELON,20,1'
-    - 'VINES,35,2'
+    - 'VINE,35,2'
 
   # Mushroom fields rewards.
   biome_mushroom_fields:

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
@@ -175,7 +175,7 @@ public class BrigadierCommandManager {
                 .executes(this::executeDrops)
                 .then(Commands.literal("preview")
                     .requires(source -> source.getSender().hasPermission(PermissionNodes.ADMIN_DEBUG))
-                    .then(Commands.argument("biome", StringArgumentType.string())
+                    .then(Commands.argument("biome", StringArgumentType.greedyString())
                         .suggests(this::suggestBiomes)
                         .executes(this::executeDropsPreview)))
                 .then(Commands.argument(KEY_CATEGORY, StringArgumentType.word())

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/internal/config/LanguageFileLoader.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/internal/config/LanguageFileLoader.java
@@ -18,7 +18,7 @@ import io.xcutiboo.mythicrod.config.LanguageManager;
 import io.xcutiboo.mythicrod.paper.util.PrettyLogger;
 
 public final class LanguageFileLoader {
-    private static final String[] BUNDLED_LANGS = {"en_US", "ja_JP"};
+    private static final String[] BUNDLED_LANGS = {"en_US", "en_GB", "ja_JP"};
 
     private final JavaPlugin plugin;
     private final Logger logger;


### PR DESCRIPTION
## Summary

Three bugs surfaced by an end-to-end Paper 26.1.2 server run.

- en_GB was on disk but `LanguageFileLoader.BUNDLED_LANGS` only listed `en_US` and `ja_JP`, so the locale was never registered. Added `en_GB` to that array. The brigadier locale suggester and `/mythicrod config language` now see it.
- `/mythicrod drops preview minecraft:ocean` failed with `Expected whitespace to end one argument, but found trailing data`. Brigadier's `StringArgumentType.string()` reads an unquoted single word with a restricted character set that does not include `:`. Switched the biome arg to `StringArgumentType.greedyString()` since biome is the last positional. Validation against the live biome registry stays intact.
- `mythicrod-common/src/main/resources/drops.yml` referenced the legacy `VINES` material in `biome_jungle`. The current registry has `VINE`. `/mythicrod validate` correctly flagged it. Fixed.

## Test plan
- [x] `./gradlew clean build` (28 tasks, success)
- [x] `./gradlew test` (114 tests, 0 failures)
- [x] Live Paper 26.1.2 server: `/mythicrod drops preview minecraft:ocean` returns the eligible drop list
- [x] Live Paper 26.1.2 server: `/mythicrod drops preview minecraft:notabiome` returns the unknown-biome error
- [x] Live Paper 26.1.2 server: `/mythicrod validate` no longer flags VINES
- [x] Live Paper 26.1.2 server: `/mythicrod config language en_GB` accepts the locale after the fix

## Summary by Sourcery

Fix language registration, biome preview argument handling, and a mismatched material in default drops configuration.

Bug Fixes:
- Register the bundled en_GB locale so it is available for configuration and suggestions.
- Allow the drops preview command to accept biome names with colons by using a greedy biome argument.
- Correct the jungle biome drops configuration to use the current VINE material name instead of the legacy VINES entry.