### PR TITLE
Docs split: release + localization subpages, Folia + Crowdin verified

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,11 +1,18 @@
 ---
 title: Localization
 nav_order: 12
+has_children: true
 ---
 
 # Localization
 
 ![divider]({{ site.baseurl }}/assets/divider.svg)
+
+## Children
+
+- [Crowdin]({{ site.baseurl }}/localization/crowdin.html)
+- [Translation style guide]({{ site.baseurl }}/localization/style-guide.html)
+- [Sync runbook]({{ site.baseurl }}/localization/sync-runbook.html)
 
 MythicRod ships English (`en_US`), British English (`en_GB`), and Japanese
 (`ja_JP`) out of the box. Every other language is community-driven through

--- a/docs/localization/crowdin.md
+++ b/docs/localization/crowdin.md
@@ -1,0 +1,87 @@
+---
+title: Crowdin
+parent: Localization
+nav_order: 1
+---
+
+# Crowdin
+
+## What MythicRod uses Crowdin for
+
+Crowdin is the single source of truth for community translations.
+The English source file (`en_US.yml`) ships with the plugin; everything
+else flows through Crowdin to a `l10n_master` branch, where translators
+get a real review path before changes land on `master`.
+
+Crowdin project: <https://crowdin.com/project/mythicrod>
+
+## Repo wiring
+
+```
+crowdin.yml
+.github/workflows/crowdin.yml       # scheduled source sync + l10n PR
+.github/workflows/crowdin-seed.yml  # one-shot bundled translation upload
+```
+
+| Repo value | Type | Purpose |
+| --- | --- | --- |
+| `CROWDIN_PROJECT_ID` | variable | Numeric Crowdin project id |
+| `CROWDIN_PERSONAL_TOKEN` | secret | API token (any user with write access) |
+
+Both workflows skip silently when those are missing.
+
+## Languages and locale codes
+
+| Bundled file | Crowdin language code |
+| --- | --- |
+| `en_US.yml` | source |
+| `en_GB.yml` | `en-GB` (must be enabled on the Crowdin project) |
+| `ja_JP.yml` | `ja` |
+
+Mappings for every other target locale live in `crowdin.yml` under
+`languages_mapping.locale_with_underscore`.
+
+If a bundled translation does not appear in Crowdin after the seed
+workflow runs, the most common cause is that the target language is not
+yet enabled in the Crowdin project. Enable it under **Project settings →
+Languages**, then re-run **Crowdin seed translations** from the GitHub
+Actions tab.
+
+## Sync model
+
+```
+master (en_US.yml)
+   │
+   ▼  crowdin.yml workflow (scheduled / push)
+Crowdin source pool
+   │
+   ▼  translators submit + approve
+Crowdin translations
+   │
+   ▼  crowdin.yml workflow downloads
+l10n_master branch + auto PR back to master
+```
+
+The translation PR is `l10n: sync Crowdin translations`. Merge it the
+same way as any other PR.
+
+## Why local edits to non-source locale files might disappear
+
+A direct edit to `ja_JP.yml` on `master` survives until the next
+download from Crowdin. The Crowdin workflow's `update_option:
+update_as_unapproved` means it does not silently overwrite approved
+translations, but the auto-PR can still revert manual edits if Crowdin
+holds a different (approved) string for the same key. Always upload the
+change through Crowdin if you want it to stick.
+
+## What never to translate
+
+- product names (`MythicRod`, `Nexo`, `Paper`, `Folia`, `Bukkit`)
+- command literals (`mythicrod`, `rod`, `select`, `add`, `set`)
+- permission nodes (`mythicrod.admin.config` and so on)
+- MiniMessage tag names (`<gold>`, `<gray>`, `<bold>`)
+- `%placeholder%` tokens
+
+[← Localization]({{ site.baseurl }}/localization/) ·
+[Style guide]({{ site.baseurl }}/localization/style-guide.html) ·
+[Sync runbook]({{ site.baseurl }}/localization/sync-runbook.html)

--- a/docs/localization/style-guide.md
+++ b/docs/localization/style-guide.md
@@ -1,0 +1,73 @@
+---
+title: Style guide
+parent: Localization
+nav_order: 2
+---
+
+# Translation style guide
+
+Keep MythicRod messages short, calm, and easy to skim. The plugin sends
+a lot of chat lines during a single catch.
+
+## Tone
+
+- Plain, practical, direct.
+- No marketing.
+- No filler words.
+- No em dashes.
+- Friendly, not cute.
+
+## Structure
+
+| Type | Tone | Notes |
+| --- | --- | --- |
+| Player chat | conversational | short sentence, single line |
+| Admin chat | precise | name the offending value when a command fails |
+| GUI labels | concise | one to three words |
+| GUI lore | sentence fragments | one per line |
+| Errors | actionable | tell the player or admin what to do next |
+| Catch messages | excited but small | reserve emphasis for rare and legendary |
+
+## Symbols
+
+- `✓` for success messages
+- `✗` for errors
+- `⚠` for warnings
+- `⟳` for in-progress state
+- Mirror the source for new keys
+
+## MiniMessage
+
+Tags travel with the value. Translate the words, not the tags.
+
+```yaml
+ok: '<green>✓ <gray>%count%<gray> drops loaded.'
+```
+
+Keep `<green>`, `<gray>`, `<green>` exactly where they are. Reorder the
+sentence around the placeholders if the target language reads better that
+way.
+
+## Placeholders
+
+`%count%`, `%player%`, `%tier%`, `%biome%`, `%locale%`, `%mode%`, and
+similar tokens are filled at runtime. The locale parity test refuses to
+merge a translation that adds, drops, or renames a token.
+
+You can reorder tokens inside a sentence to match the target language.
+You cannot rename them.
+
+## Names that stay in English
+
+| Term | Why |
+| --- | --- |
+| `MythicRod` | product name |
+| `Paper`, `Folia`, `Bukkit` | platform names |
+| `Nexo` | dependency name |
+| `mythicrod.gui`, `mythicrod.admin.config`, etc. | permission identifiers |
+| `/mythicrod`, `/mr`, `/mrod` | command literals |
+| Material keys (`DIAMOND`, `NETHER_STAR`, ...) | code identifiers |
+| Locale codes (`en_US`, `ja_JP`) | machine-readable |
+
+[← Localization]({{ site.baseurl }}/localization/) ·
+[Crowdin]({{ site.baseurl }}/localization/crowdin.html)

--- a/docs/localization/sync-runbook.md
+++ b/docs/localization/sync-runbook.md
@@ -1,0 +1,77 @@
+---
+title: Sync runbook
+parent: Localization
+nav_order: 3
+---
+
+# Crowdin sync runbook
+
+Use this when adding a new bundled locale, recovering after a Crowdin
+outage, or moving the project to a different organisation.
+
+## Daily operation
+
+There is no daily operation. The `crowdin.yml` workflow runs on every
+push that touches `en_US.yml`, on a Monday cron, and on manual dispatch.
+Translation PRs land automatically on `l10n_master` and target `master`.
+
+## Adding a new bundled locale
+
+1. Copy `en_US.yml` into the new file (for example `de_DE.yml`).
+2. Translate the values only. Keep keys, MiniMessage tags, and
+   `%placeholder%` tokens identical to the source.
+3. Add the locale code to
+   `mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/internal/config/LanguageFileLoader.java`,
+   the `BUNDLED_LANGS` array.
+4. Add the locale to
+   `mythicrod-paper/src/test/java/io/xcutiboo/mythicrod/paper/internal/config/BundledLocaleParityTest.java`,
+   the `BUNDLED_TARGETS` list.
+5. Make sure the mapping is in `crowdin.yml` under
+   `languages_mapping.locale_with_underscore`. Add it if missing.
+6. Run `./gradlew :mythicrod-paper:test`. The parity test catches drift.
+7. Enable the target language in the Crowdin project under
+   **Project settings → Languages**.
+8. Push the branch, open the PR, merge it.
+9. From the **Actions** tab, run **Crowdin seed translations**. It
+   uploads the bundled translation file once so Crowdin sees it.
+10. Verify the new language appears in the Crowdin dashboard with the
+    seeded strings as imported but unapproved.
+
+## When a translation does not appear in Crowdin
+
+Symptom: `ja_JP.yml` is bundled but Crowdin only shows source strings.
+
+Reason: the scheduled `crowdin.yml` workflow only uploads the source.
+Translations need a one-time seed run.
+
+Fix:
+1. Verify `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN` are set
+   under **Settings → Secrets and variables → Actions**.
+2. From the **Actions** tab, run **Crowdin seed translations**.
+3. Confirm the workflow logs `✔ File ... ja_JP.yml`.
+4. Reload the Crowdin project page. The language tile should now show
+   imported strings.
+
+## When the Crowdin auto-PR breaks
+
+Symptom: the `l10n: sync Crowdin translations` PR fails to open, or the
+download step says `no translation file to commit`.
+
+Likely causes:
+- No translator has submitted anything new since the last successful
+  download. This is fine.
+- Crowdin lost track of the source file because the source file path
+  changed. Open `crowdin.yml`, confirm the `source:` path matches the
+  current repo, then re-run the workflow.
+- `CROWDIN_PERSONAL_TOKEN` was rotated. Update the secret.
+
+## Rotating the Crowdin token
+
+1. <https://crowdin.com/settings#api-key> → revoke the old token.
+2. Create a new one with write access on the project.
+3. `gh secret set CROWDIN_PERSONAL_TOKEN --body '<token>'`
+4. Re-run **Crowdin seed translations** to confirm it works.
+
+[← Localization]({{ site.baseurl }}/localization/) ·
+[Crowdin]({{ site.baseurl }}/localization/crowdin.html) ·
+[Style guide]({{ site.baseurl }}/localization/style-guide.html)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,7 @@
 ---
 title: Release guide
 nav_order: 11
+has_children: true
 ---
 
 # Release guide
@@ -11,6 +12,13 @@ Step-by-step for cutting a public release of MythicRod. Every secret named
 here is configured at **Settings → Secrets and variables → Actions** on the
 GitHub repository. Nothing in this file expects you to paste a token into a
 file on disk.
+
+## Children
+
+- [Hangar publishing]({{ site.baseurl }}/release/hangar.html)
+- [Modrinth publishing]({{ site.baseurl }}/release/modrinth.html)
+- [GitHub Actions reference]({{ site.baseurl }}/release/github-actions.html)
+- [Release checklist]({{ site.baseurl }}/release/checklist.html)
 
 ## 1. Required repo secrets
 

--- a/docs/release/checklist.md
+++ b/docs/release/checklist.md
@@ -1,0 +1,78 @@
+---
+title: Release checklist
+parent: Release guide
+nav_order: 4
+---
+
+# Release checklist
+
+Hand-checkable list. Run top to bottom before tagging.
+
+## Code
+
+- [ ] `git status` clean on `master`
+- [ ] `./gradlew clean build` green
+- [ ] `./gradlew test` green (114+ tests)
+- [ ] `mythicrod-paper/build/libs/MythicRod-Paper-<version>.jar` exists
+- [ ] `mythicrod-spigot/build/libs/MythicRod-Spigot-<version>.jar` exists
+- [ ] No `System.out`, `System.err`, `printStackTrace`, TODO, FIXME, or
+      em dash in the tracked tree (`./scripts` not present; use
+      ripgrep)
+- [ ] `paper-plugin.yml` matches latest Paper API generation
+
+## Live servers
+
+- [ ] Paper server starts cleanly with the new jar
+- [ ] Folia server starts cleanly with the new jar
+- [ ] `mythicrod status` runs on both
+- [ ] `mythicrod reload` runs on both
+- [ ] `mythicrod drops preview minecraft:ocean` runs on both
+- [ ] Player-only commands fail cleanly from console
+- [ ] No exceptions in the server log during shutdown
+
+## Locales
+
+- [ ] `BundledLocaleParityTest` green
+- [ ] `LanguageFileLoader.BUNDLED_LANGS` lists every bundled locale
+- [ ] Crowdin shows en_US as source
+- [ ] Crowdin shows ja_JP (and en_GB once the target language is
+      enabled on the Crowdin project) under translations
+
+## Docs
+
+- [ ] `CHANGELOG.md` has the new release entry at the top
+- [ ] `README.md` version badge points at the upcoming tag
+- [ ] `docs/index.md` version-targets table updated
+- [ ] `docs/release.md` matches the workflows
+- [ ] All Pages workflow links resolve
+
+## Secrets
+
+- [ ] `HANGAR_API_TOKEN` exists
+- [ ] `MODRINTH_TOKEN` exists and passes the probe
+- [ ] `CROWDIN_PERSONAL_TOKEN` exists
+- [ ] `CROWDIN_PROJECT_ID` variable exists
+- [ ] `SONAR_TOKEN` exists
+
+## Tag and push
+
+```bash
+git tag v<version>
+git push origin v<version>
+```
+
+Three workflows fire in parallel:
+
+- `Build and Release` creates the GitHub release
+- `Publish to Hangar` uploads the Paper jar
+- `Publish to Modrinth` uploads the Paper jar
+
+## After publish
+
+- [ ] GitHub release page lists the jar + `.sha256`
+- [ ] Hangar version page is live
+- [ ] Modrinth version page is live
+- [ ] Update `docs/index.md` version-targets table to the next planned
+      version
+
+[← Release guide]({{ site.baseurl }}/release/)

--- a/docs/release/github-actions.md
+++ b/docs/release/github-actions.md
@@ -1,0 +1,56 @@
+---
+title: GitHub Actions
+parent: Release guide
+nav_order: 3
+---
+
+# GitHub Actions
+
+Every workflow lives in `.github/workflows/`. Each one is SHA-pinned to a
+specific upstream commit so a tag rewrite upstream cannot change CI
+behaviour.
+
+## Workflows
+
+| File | Trigger | What it does |
+| --- | --- | --- |
+| `build.yml` | push to `master`, PR, tag `v*` | `./gradlew clean build` + JUnit + tests artifact + tagged release jar with SHA-256 |
+| `codeql.yml` | push to `master`, PR, Monday cron | CodeQL scan for `java-kotlin` |
+| `sonar.yml` | push to `master`, PR | SonarCloud scan against `xcutiboo_MythicRod` |
+| `pages.yml` | push to `master` when `docs/**` changes | Builds Jekyll site and deploys to GitHub Pages |
+| `dependency-review.yml` | PR | Blocks PRs introducing high-severity vulnerable deps |
+| `crowdin.yml` | push to `master` when source file or workflow changes, Monday cron, manual | Uploads `en_US.yml` source, downloads translations, opens l10n PR on `l10n_master` |
+| `crowdin-seed.yml` | manual | One-shot upload of bundled translations |
+| `publish-hangar.yml` | tag `v*`, manual | Hangar publish |
+| `publish-modrinth.yml` | tag `v*`, manual | Modrinth publish |
+
+## Required secrets
+
+| Name | Type | Used by |
+| --- | --- | --- |
+| `HANGAR_API_TOKEN` | secret | `publish-hangar.yml` |
+| `MODRINTH_TOKEN` | secret | `publish-modrinth.yml` |
+| `CROWDIN_PERSONAL_TOKEN` | secret | `crowdin.yml`, `crowdin-seed.yml` |
+| `SONAR_TOKEN` | secret | `sonar.yml` |
+| `CROWDIN_PROJECT_ID` | variable | both Crowdin workflows |
+| `SONAR_PROJECT_KEY` | variable | `sonar.yml` |
+
+All publish workflows short-circuit cleanly when their secrets are
+missing. Normal CI does not depend on them.
+
+## Permissions
+
+Every workflow declares the minimum permissions it needs. Build and
+release write to release assets only when triggered by a tag. Pages
+writes only the Pages artifact. CodeQL writes only security events.
+
+## When to re-run
+
+- Failed CodeQL or SonarCloud upload: re-trigger the workflow from the
+  Actions UI. They are idempotent.
+- Failed Pages build: usually a broken doc link or a Jekyll plugin
+  conflict. The `pages.yml` workflow log points at the file.
+- Failed publish workflow: do not retag. Trigger the workflow manually
+  from the Actions UI after fixing the underlying error.
+
+[← Release guide]({{ site.baseurl }}/release/)

--- a/docs/release/hangar.md
+++ b/docs/release/hangar.md
@@ -1,0 +1,62 @@
+---
+title: Hangar
+parent: Release guide
+nav_order: 1
+---
+
+# Hangar publishing
+
+## What this does
+
+Pushes the MythicRod Paper jar to the project page at
+<https://hangar.papermc.io/xcutiboo/MythicRod> whenever a `v*` tag lands
+on `master`.
+
+## What it uses
+
+- `.github/workflows/publish-hangar.yml`
+- `io.papermc.hangar-publish-plugin` configured in
+  `mythicrod-paper/build.gradle.kts`
+- Repository secret: `HANGAR_API_TOKEN`
+- Project slug: `MythicRod`
+
+## Required secret
+
+1. Go to <https://hangar.papermc.io/auth/settings/api-keys>.
+2. Create a key with `create_version` permission on the MythicRod
+   project.
+3. Save it to the repo as `HANGAR_API_TOKEN` at
+   <https://github.com/xcutiboo/MythicRod/settings/secrets/actions>.
+
+## What gets uploaded
+
+| Field | Source |
+| --- | --- |
+| Version | tag with the leading `v` stripped |
+| Channel | `Snapshot` for any version containing `-`, else `Release` |
+| Jar | `mythicrod-paper/build/libs/MythicRod-Paper-<version>.jar` |
+| Changelog | `CHANGELOG.md` from the tagged commit |
+| Platform | Paper |
+| Platform versions | value of `paperVersion` in `gradle.properties` |
+
+## Smoke check before the first release
+
+```bash
+gh workflow run publish-hangar.yml --ref master
+gh run watch
+```
+
+The workflow logs `Skipping Hangar publish: HANGAR_API_TOKEN is not
+configured.` when the secret is missing. That is the safe failure mode.
+
+## When something fails
+
+- 401 / 403 from Hangar: token expired or missing scope. Regenerate the
+  key.
+- 409 conflict on version: the same version already exists on Hangar.
+  Delete it from the Hangar UI or pick a new tag.
+- Missing jar: `shadowJar` is required. The release workflow does run it,
+  but a `runs-on` change or cache regression can cause a stale build.
+  Re-run from a clean workflow trigger.
+
+[← Release guide]({{ site.baseurl }}/release/)

--- a/docs/release/modrinth.md
+++ b/docs/release/modrinth.md
@@ -1,0 +1,61 @@
+---
+title: Modrinth
+parent: Release guide
+nav_order: 2
+---
+
+# Modrinth publishing
+
+## What this does
+
+Uploads the MythicRod Paper jar to
+<https://modrinth.com/plugin/mythicrod> on every `v*` tag.
+
+## What it uses
+
+- `.github/workflows/publish-modrinth.yml`
+- `Kir-Antipov/mc-publish@v3.3`
+- Repository secret: `MODRINTH_TOKEN`
+- Modrinth project slug: `mythicrod` (id `Uc7DXvOG`)
+
+## Required secret
+
+1. Go to <https://modrinth.com/settings/pats>.
+2. Create a personal access token. Scopes needed:
+   - `read_projects`
+   - `write_projects`
+   - `create_versions`
+   - `read_versions`
+   - `write_versions`
+3. Save it as `MODRINTH_TOKEN`.
+
+## What gets uploaded
+
+| Field | Value |
+| --- | --- |
+| Version number | tag with the leading `v` stripped |
+| Version type | `beta` for tags containing `-rc`, `-beta`, `-alpha`, or `-snapshot`; `release` otherwise |
+| Files | `MythicRod-Paper-<version>.jar` (the shaded jar) |
+| Name | `MythicRod <version>` |
+| Loaders | `paper`, `folia` |
+| Game versions | `1.21.11` |
+| Changelog | `CHANGELOG.md` |
+| Dependencies | Nexo as optional |
+| Fail mode | `warn` (workflow does not abort on a single field complaint) |
+
+## Smoke check before the first release
+
+The workflow short-circuits with `MODRINTH_TOKEN is not configured;
+skipping Modrinth publish.` when the secret is missing.
+
+## When something fails
+
+- `401 Invalid Authentication Credentials`: the token is malformed
+  (whitespace, quotes, or wrong scope). Regenerate the PAT and re-store
+  it via `gh secret set MODRINTH_TOKEN --body '<token>'`.
+- 409 conflict on version: that version is already on Modrinth. Either
+  delete it from the Modrinth UI or pick a new tag.
+- Missing jar: `shadowJar` did not run. Re-trigger the workflow from a
+  clean cache.
+
+[← Release guide]({{ site.baseurl }}/release/)


### PR DESCRIPTION
## Summary

Folia validation + Crowdin seed actually performed, then the release and localization docs split into focused child pages so a server owner doesn't get dropped into a single overloaded manual.

### Verified live

- Paper 26.1.2 + MythicRod 2026.1.0: all server-side commands pass.
- Folia 26.1.2 build 8 + MythicRod 2026.1.0: all server-side commands pass. Runtime reports as `Folia` from `/mythicrod status`. No exceptions during shutdown.
- Crowdin seed workflow ran. `en_US.yml` source uploaded. `ja_JP.yml` translation imported into the Crowdin project. `en_GB.yml` will appear once the en-GB language is enabled on the Crowdin project (UI step, no repo change needed).

### Docs

New parent + child layout:

- `docs/release.md` (parent) + `release/hangar.md`, `release/modrinth.md`, `release/github-actions.md`, `release/checklist.md`
- `docs/localization.md` (parent) + `localization/crowdin.md`, `localization/style-guide.md`, `localization/sync-runbook.md`

Doc link audit: 0 broken.

## Test plan

- [x] `./gradlew clean build` green (28 tasks)
- [x] `./gradlew test` green (114 tests)
- [x] Paper 26.1.2 RCON command suite green
- [x] Folia 26.1.2 RCON command suite green
- [x] Crowdin seed workflow run `26263587138` green
- [x] Doc link audit clean

## Summary by Sourcery

Split release and localization documentation into parent pages with focused child guides for publishing workflows and Crowdin localization, adding detailed checklists and runbooks for releases and translation sync.

Documentation:
- Document Hangar publishing setup and behaviour, including required secrets and failure modes.
- Document Modrinth publishing workflow, configuration, and troubleshooting steps.
- Add a GitHub Actions reference page summarizing all CI and release workflows and their required secrets and permissions.
- Create a release checklist covering code, live servers, locales, docs, secrets, and post-publish verification steps.
- Expand localization docs with dedicated pages for Crowdin usage, translation style guidelines, and a Crowdin sync runbook for bundled locales.
- Mark release and localization docs as parents with explicit child navigation links for the new subpages.