### PR TITLE
Dev API subpages + Japanese tier wording + Crowdin docs

### DIFF
--- a/docs/developer-api.md
+++ b/docs/developer-api.md
@@ -1,6 +1,7 @@
 ---
 title: Developer API
 nav_order: 8
+has_children: true
 ---
 
 # MythicRod Developer API

--- a/docs/developer-api/compatibility-policy.md
+++ b/docs/developer-api/compatibility-policy.md
@@ -1,0 +1,58 @@
+---
+title: Compatibility policy
+parent: Developer API
+nav_order: 6
+---
+
+# Compatibility policy
+
+MythicRod uses CalVer: `<year>.<release>.<patch>`.
+
+## What patch releases guarantee
+
+A patch release (`2026.1.1` after `2026.1.0`) is **binary-compatible**.
+You can drop the new jar onto a server without recompiling dependent
+plugins. Bug fixes only.
+
+## What minor releases guarantee
+
+A minor release (`2026.2.0` after `2026.1.0`) adds new API methods only
+with default implementations or new types. Existing types stay
+binary-compatible. Recompilation is not required.
+
+## What year roll-overs may change
+
+A year roll-over (`2027.1.0` after `2026.x`) may rename or remove API
+**only when the changelog calls it out explicitly**. Expect at least
+one minor release marked deprecated before any removal.
+
+## What lives outside the contract
+
+- everything under `io.xcutiboo.mythicrod.drops.*`
+- internal Paper runtime classes outside
+  `io.xcutiboo.mythicrod.paper.api.*` and
+  `io.xcutiboo.mythicrod.paper.events.*`
+- field shapes on internal `CustomDrop`
+- log message formatting
+- locale key paths (those live under MythicRod's lang loader)
+
+Pin against the stable surfaces:
+
+| Stable | Internal |
+| --- | --- |
+| `io.xcutiboo.mythicrod.api` | `io.xcutiboo.mythicrod.drops` |
+| `io.xcutiboo.mythicrod.api.drop` | `io.xcutiboo.mythicrod.text` |
+| `io.xcutiboo.mythicrod.api.platform` | most of `mythicrod-paper` |
+| `io.xcutiboo.mythicrod.paper.api` | |
+| `io.xcutiboo.mythicrod.paper.events` | |
+
+## Supported Paper API
+
+| MythicRod | Paper API | Minecraft |
+| --- | --- | --- |
+| `2026.1.x` | `26.1.x` | `1.21.11` |
+
+A Paper API generation bump always lands in a year roll-over or a
+clearly-flagged minor release. Patch releases never raise the floor.
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/docs/developer-api/drop-providers.md
+++ b/docs/developer-api/drop-providers.md
@@ -1,0 +1,114 @@
+---
+title: Drop providers
+parent: Developer API
+nav_order: 4
+---
+
+# External drop providers
+
+`ExternalDropProvider` is how another plugin injects its own reward
+rolls into MythicRod's selection pipeline.
+
+## Implementation
+
+```java
+import io.xcutiboo.mythicrod.api.ExternalDropProvider;
+import io.xcutiboo.mythicrod.api.MythicRodAPI;
+import io.xcutiboo.mythicrod.api.platform.PlatformItem;
+import io.xcutiboo.mythicrod.api.platform.PlatformPlayer;
+
+public final class VipReward implements ExternalDropProvider {
+    public static final String KEY = "myplugin:vip";
+
+    private final MythicRodAPI api;
+    public VipReward(MythicRodAPI api) { this.api = api; }
+
+    @Override public String getKey() { return KEY; }
+
+    @Override
+    public double getWeight(PlatformPlayer player) {
+        return player.hasPermission("myplugin.vip") ? 4.0D : 0.0D;
+    }
+
+    @Override
+    public PlatformItem generateItem(PlatformPlayer player) {
+        return api.createItem("DIAMOND", 1).orElse(null);
+    }
+
+    @Override public String getDisplayName() { return "<gold>VIP Diamond"; }
+    @Override public String getTier() { return "rare"; }
+}
+```
+
+## Lifecycle
+
+```java
+@Override public void onEnable() {
+    MythicRodServices.find().ifPresent(api ->
+        api.registerExternalDropProvider(new VipReward(api)));
+}
+
+@Override public void onDisable() {
+    MythicRodServices.find().ifPresent(api ->
+        api.unregisterExternalDropProvider(VipReward.KEY));
+}
+```
+
+Register inside `onEnable()` after MythicRod's service is up. Always
+use `find()` in `onDisable()` so your shutdown still completes when
+MythicRod has already gone away.
+
+## Method contracts
+
+| Method | Required | Thread |
+| --- | --- | --- |
+| `getKey()` | yes | any |
+| `getWeight(PlatformPlayer)` | yes | fishing-event path |
+| `generateItem(PlatformPlayer)` | yes | fishing-event path |
+| `getDisplayName()` | default | any |
+| `getTier()` | default | any |
+
+`getKey()` must be stable. The provider key is the durable identifier;
+display name is presentation only.
+
+`getWeight` runs on the player's owner thread (Folia) or the main
+thread (vanilla Paper). Stay non-blocking. Returning `<= 0.0` means the
+provider does not participate in that roll.
+
+`generateItem` runs in the same thread context. Returning `null` aborts
+the reward quietly and MythicRod will fall back to its built-in drop
+table.
+
+## Item creation
+
+Always create reward items through the MythicRod factory:
+
+```java
+api.createItem("DIAMOND", 1)              // vanilla material
+api.createItem("nexo:my_treasure", 1)     // Nexo-backed item
+```
+
+The factory returns a `Result<PlatformItem>` that you can `.orElse(null)`
+or `.orElseThrow()`. Never build Paper `ItemStack` directly inside a
+provider; that bypasses MythicRod's compatibility wrapper.
+
+## Thread + Folia rules
+
+- Do not call `Bukkit.getScheduler()` to leave the owner thread.
+- Do not start a network request, database query, or anything blocking
+  inside `getWeight` or `generateItem`. If you need that, pre-compute
+  the value on a different thread and read it from a cache here.
+- If you must mutate worlds, entities, or inventories from inside a
+  provider, schedule the work through `PlatformScheduler.runForPlayer`
+  or `runAtLocation` rather than calling Bukkit APIs inline.
+
+## What not to do
+
+- Do not expose your provider's internal state through `getKey()`. It
+  must be stable.
+- Do not mutate the `PlatformPlayer` you receive. It is an inspection
+  view.
+- Do not throw from `getWeight`. Any throwing provider is treated as
+  inactive for that roll.
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/docs/developer-api/events.md
+++ b/docs/developer-api/events.md
@@ -1,0 +1,108 @@
+---
+title: Events
+parent: Developer API
+nav_order: 3
+---
+
+# Paper events
+
+MythicRod publishes four Paper events. All live under
+`io.xcutiboo.mythicrod.paper.events`.
+
+| Event | Cancellable | Thread |
+| --- | --- | --- |
+| `MythicRodRewardRollEvent` | no | player-owner |
+| `MythicRodFishCatchEvent` | yes | player-owner |
+| `MythicRodStatsUpdateEvent` | no | stats writer |
+| `MythicRodReloadEvent` | no | reload-caller |
+
+## `MythicRodRewardRollEvent`
+
+Fires once MythicRod has identified eligible drops but **before** it has
+built the reward item. Bias selection here.
+
+```java
+@EventHandler
+public void onRoll(MythicRodRewardRollEvent event) {
+    if (event.getPlayer().hasPermission("myplugin.lucky")) {
+        event.setLuckMultiplier(event.getLuckMultiplier() * 1.5D);
+    }
+}
+```
+
+Mutators: `setLuckMultiplier(double)`, `forceDrop(CustomDrop)`. The
+forced-drop path is the advanced lane and bypasses weight selection;
+prefer the multiplier when you can.
+
+## `MythicRodFishCatchEvent`
+
+Fires after selection. Cancellable. The reward `ItemStack` is mutable.
+Cancelling leaves the vanilla catch in place.
+
+```java
+@EventHandler(ignoreCancelled = true)
+public void onCatch(MythicRodFishCatchEvent event) {
+    if ("legendary".equalsIgnoreCase(event.getDropView().getTier())) {
+        event.getPlayer().getWorld().strikeLightningEffect(
+            event.getPlayer().getLocation());
+    }
+}
+```
+
+`setRewardItem(ItemStack)` rejects `null` and `AIR`. Cancel the event
+instead.
+
+## `MythicRodStatsUpdateEvent`
+
+Read-only. Useful for analytics, webhooks, or sign refreshes.
+
+```java
+@EventHandler
+public void onStats(MythicRodStatsUpdateEvent event) {
+    var snap = event.getSnapshot();
+    metrics.record("mythicrod.catch", Map.of(
+        "uuid", snap.playerUuid().toString(),
+        "tier", event.getTier(),
+        "total", String.valueOf(snap.totalCaught())
+    ));
+}
+```
+
+## `MythicRodReloadEvent`
+
+Fires after `MythicRod#reload()` completes. Carries an `isSuccess()`
+flag so listeners can refresh their caches only after a real swap.
+
+```java
+@EventHandler
+public void onReload(MythicRodReloadEvent event) {
+    if (event.isSuccess()) {
+        myDropProviderCache.invalidate();
+    }
+}
+```
+
+## Threading and Folia
+
+All four events fire on the same thread that owns the data they carry:
+
+- Reward roll, fish catch: the player's owner thread on Folia, the main
+  thread on vanilla Paper.
+- Stats update: MythicRod's stats writer thread. Do not call Bukkit
+  world or entity APIs inline.
+- Reload: the thread that called `MythicRod#reload()`. For
+  `/mythicrod reload` issued from the server console on Paper, that is
+  the main thread. On Folia it is the global region scheduler.
+
+A misbehaving listener cannot break the reload. Exceptions are caught
+and logged by MythicRod.
+
+## What not to do
+
+- Do not mutate `event.getDrop()` directly. It is the internal type.
+  Use `event.getDropView()` for inspection.
+- Do not block, sleep, or wait on a future inside any event handler.
+- Do not call `Bukkit.getScheduler()` to move entity-bound work back to
+  the main thread on Folia. Use the Folia entity or region scheduler.
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/docs/developer-api/folia-threading.md
+++ b/docs/developer-api/folia-threading.md
@@ -1,0 +1,73 @@
+---
+title: Folia threading
+parent: Developer API
+nav_order: 5
+---
+
+# Folia threading
+
+MythicRod is Folia-safe out of the box. Plugins that integrate with it
+must keep the same discipline.
+
+## Owner thread concept
+
+Every entity, world region, and player has a single thread that is
+allowed to mutate its state. Folia rejects cross-thread mutation with
+runtime exceptions. Paper has the same rule but is more forgiving:
+violations there cause subtle data races instead of explicit crashes.
+
+| Owner | Use this scheduler |
+| --- | --- |
+| a `Player` or `Entity` | entity scheduler (`runForPlayer`) |
+| a `Location` or block | region scheduler (`runAtLocation`) |
+| server-wide bookkeeping | global scheduler (`runGlobal`) |
+| pure computation / blocking I/O | async scheduler (`runAsync`) |
+
+`PlatformScheduler` is MythicRod's API-side facade; the runtime picks
+the right Bukkit/Folia API for you.
+
+## Where each API surface runs
+
+| Surface | Thread |
+| --- | --- |
+| `MythicRodAPI.getPlayerStats(uuid)` | async completion |
+| `MythicRodAPI.getTopPlayers(type, limit)` | async completion |
+| `MythicRodAPI.flushAllStats()` | async completion |
+| `ExternalDropProvider.getWeight` | player owner thread |
+| `ExternalDropProvider.generateItem` | player owner thread |
+| `MythicRodRewardRollEvent` | player owner thread |
+| `MythicRodFishCatchEvent` | player owner thread |
+| `MythicRodStatsUpdateEvent` | stats writer thread |
+| `MythicRodReloadEvent` | reload-caller thread |
+
+## Safe pattern
+
+```java
+api.getTopPlayers(StatType.TOTAL_CAUGHT, 10).thenAccept(top -> {
+    // we are on a MythicRod async thread here.
+    // schedule UI updates back to the owner.
+    api.getScheduler().runForPlayer(viewer, () -> updateSign(top));
+});
+```
+
+## Unsafe pattern
+
+```java
+api.getTopPlayers(StatType.TOTAL_CAUGHT, 10).thenAccept(top -> {
+    viewer.sendMessage("..."); // BAD: async Bukkit call
+    sign.setLine(0, "..."); // BAD: world mutation off-thread
+});
+```
+
+## Rules of thumb
+
+- Treat every `CompletableFuture` callback as async.
+- After any async hop, schedule back to the correct owner before
+  touching Bukkit state.
+- Do not call `Bukkit.getScheduler()` from API code. It violates Folia
+  region rules. Use `PlatformScheduler` instead.
+- Do not block, sleep, or wait on a future inside an event handler or
+  drop provider.
+- Do not assume one global tick thread on Folia. There is none.
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/docs/developer-api/service-access.md
+++ b/docs/developer-api/service-access.md
@@ -1,0 +1,66 @@
+---
+title: Service access
+parent: Developer API
+nav_order: 2
+---
+
+# Service access
+
+MythicRod registers a single `MythicRodAPI` service through Bukkit's
+`ServicesManager`. There are three entry points:
+
+## Preferred Paper lookup
+
+```java
+import io.xcutiboo.mythicrod.api.MythicRodAPI;
+import io.xcutiboo.mythicrod.paper.api.MythicRodServices;
+
+MythicRodAPI api = MythicRodServices.require();
+```
+
+`require()` throws `IllegalStateException` if MythicRod is not loaded.
+Use it inside `onEnable()` after the load-order dependency makes sure
+MythicRod is ready.
+
+## Optional lookup
+
+```java
+MythicRodServices.find().ifPresent(api -> {
+    // integrate here
+});
+```
+
+`find()` returns an `Optional`. Use it if MythicRod is a soft dependency
+or in a shutdown path where MythicRod may already be disabled.
+
+## Server / ServicesManager overloads
+
+For tests or alternative entry points:
+
+```java
+MythicRodAPI api = MythicRodServices.require(Bukkit.getServer());
+```
+
+## Raw Bukkit lookup
+
+If you do not link the Paper helper module:
+
+```java
+RegisteredServiceProvider<MythicRodAPI> p =
+    Bukkit.getServicesManager().getRegistration(MythicRodAPI.class);
+MythicRodAPI api = p != null ? p.getProvider() : null;
+```
+
+## Reload behaviour
+
+`MythicRod#reload()` does not re-register the service. The same
+`MythicRodAPI` instance survives reload. Listeners may want to react to
+`MythicRodReloadEvent` to refresh their own caches.
+
+## Plugin enable order
+
+Declare `load: AFTER, required: false` on MythicRod in your plugin's
+`paper-plugin.yml`. That guarantees the service is registered before
+your `onEnable()` runs.
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/docs/developer-api/setup.md
+++ b/docs/developer-api/setup.md
@@ -1,0 +1,81 @@
+---
+title: Setup
+parent: Developer API
+nav_order: 1
+---
+
+# Setup
+
+## Gradle (Kotlin DSL)
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven("https://repo.papermc.io/repository/maven-public/")
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    compileOnly(files("libs/MythicRod-Paper-2026.1.0.jar"))
+}
+```
+
+Drop the released MythicRod jar into your project's `libs/` folder.
+Keep it `compileOnly`. Never shade or relocate it.
+
+## Gradle (Groovy)
+
+```groovy
+dependencies {
+    compileOnly 'io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT'
+    compileOnly files('libs/MythicRod-Paper-2026.1.0.jar')
+}
+```
+
+## Maven
+
+```xml
+<dependency>
+  <groupId>io.papermc.paper</groupId>
+  <artifactId>paper-api</artifactId>
+  <version>1.21.11-R0.1-SNAPSHOT</version>
+  <scope>provided</scope>
+</dependency>
+<dependency>
+  <groupId>io.xcutiboo</groupId>
+  <artifactId>mythicrod-paper</artifactId>
+  <version>2026.1.0</version>
+  <scope>system</scope>
+  <systemPath>${project.basedir}/libs/MythicRod-Paper-2026.1.0.jar</systemPath>
+</dependency>
+```
+
+## paper-plugin.yml dependency
+
+Declare MythicRod as an after-load optional dependency so the API
+service is registered before your plugin reaches for it:
+
+```yaml
+name: YourPlugin
+main: example.YourPlugin
+api-version: '1.21'
+dependencies:
+  server:
+    MythicRod:
+      load: AFTER
+      required: false
+```
+
+Handle the missing-service case cleanly when MythicRod is optional.
+
+## Plugin version compatibility
+
+| Plugin version | Paper API | Java | Folia |
+| --- | --- | --- | --- |
+| `2026.1.x` | `26.1.x` (1.21.11) | 25 | supported |
+
+Patch releases never break the API. Minor releases add methods with
+default implementations only. Year roll-overs may rename or remove API
+only when the changelog calls it out explicitly.
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/docs/localization/crowdin.md
+++ b/docs/localization/crowdin.md
@@ -65,6 +65,51 @@ l10n_master branch + auto PR back to master
 The translation PR is `l10n: sync Crowdin translations`. Merge it the
 same way as any other PR.
 
+## Why a one-time seed is needed for bundled translations
+
+The scheduled workflow only **uploads the source file** and downloads
+finished translations. It does not upload existing translated files,
+because re-uploading them on every push could overwrite reviewer work on
+Crowdin.
+
+That means a freshly added bundled locale (for example `ja_JP.yml`
+shipped with the plugin) sits on disk, but Crowdin has no record of it.
+The **Crowdin seed translations** workflow does the one-time upload
+explicitly:
+
+```
+.github/workflows/crowdin-seed.yml
+  upload_sources: true
+  upload_translations: true
+  auto_approve_imported: false   # seeded strings stay unapproved
+  import_eq_suggestions: false   # exact matches do not silently override
+```
+
+Run it from the Actions tab after:
+- adding a new bundled locale to the repo
+- enabling a new target language in the Crowdin project
+- recovering from a Crowdin project rebuild
+
+After the seed completes, the language tile on the Crowdin dashboard
+shows imported strings. From there on, the scheduled workflow handles
+source pushes and translation pulls automatically.
+
+## When a freshly enabled target language still shows nothing
+
+Symptom: en-GB (or any new target) was enabled in Crowdin settings, but
+the project dashboard still shows zero strings for it.
+
+Fix:
+1. Confirm the target language is checked under **Project settings →
+   Languages → Target Languages** and the *section-local* Save button
+   under that list was clicked.
+2. Verify the language code in `crowdin.yml` matches the Crowdin code.
+   For example `en-GB → en_GB`.
+3. Trigger **Crowdin seed translations** from Actions. The action log
+   should print `Importing translations for file '.../<locale>.yml'`
+   followed by `✔ File '...'`.
+4. Reload the Crowdin dashboard. The tile updates within a few seconds.
+
 ## Why local edits to non-source locale files might disappear
 
 A direct edit to `ja_JP.yml` on `master` survives until the next

--- a/mythicrod-common/src/main/resources/config.yml
+++ b/mythicrod-common/src/main/resources/config.yml
@@ -23,7 +23,8 @@ ui:
   prefix: '<gold><bold>[MythicRod]</bold></gold> '
 
 language:
-  # Supported: en_US, ja_JP (defaults to en_US if invalid)
+  # Bundled: en_US, en_GB, ja_JP. Drop additional locale files in
+  # plugins/MythicRod/lang/ to add more. Falls back to en_US if invalid.
   default: en_US
 
 messages:

--- a/mythicrod-paper/src/main/resources/lang/ja_JP.yml
+++ b/mythicrod-paper/src/main/resources/lang/ja_JP.yml
@@ -47,8 +47,8 @@ command:
     invalid: '<red>✗ <dark_red>不明なモード <yellow>%mode%<dark_red>。<yellow>normal<dark_red> または <yellow>reduced<dark_red> を使用してください。'
   rod:
     opened: '<green>✓ <gray>ロッド設定を開きました。'
-    selected: '<green>✓ <gray>ロッド階級を <white>%tier%<gray> に設定しました。'
-    locked: '<red>✗ <dark_red>階級 <yellow>%tier%<dark_red> を使用する権限がありません。'
+    selected: '<green>✓ <gray>ロッドティアを <white>%tier%<gray> に切り替えました。'
+    locked: '<red>✗ <dark_red>ティア <yellow>%tier%<dark_red> を使用する権限がありません。'
   give:
     tier-missing: '<red>✗ <dark_red>ティアを空にはできません。'
     invalid-tier: '<red>✗ <dark_red>無効なティア <yellow>%tier%<dark_red> です。<yellow>basic<dark_red>、<yellow>advanced<dark_red>、<yellow>legendary<dark_red> を使用してください。'
@@ -734,7 +734,7 @@ gui:
       lore3: '<dark_gray>通常の釣りに最適です'
       equipped: '<green>✓ 装備中'
       click: '<yellow>▶ クリックして装備'
-      selected: '<green>✓ ロッド tier を Basic に変更しました。'
+      selected: '<green>✓ <gray>ベーシックロッドに切り替えました。'
     advanced:
       label: 'Advanced'
       name: '<aqua><bold>アドバンスドロッド'
@@ -744,8 +744,8 @@ gui:
       lore4: '<yellow>さらなる成長向けに設計されています'
       equipped: '<green>✓ 装備中'
       click: '<yellow>▶ クリックして装備'
-      selected: '<green>✓ ロッド tier を Advanced に変更しました。'
-      locked: '<red>✗ Advanced ロッドを使う権限が必要です。'
+      selected: '<green>✓ <gray>アドバンスドロッドに切り替えました。'
+      locked: '<red>✗ <dark_red>アドバンスドロッドを使う権限がありません。'
     legendary:
       label: 'Legendary'
       name: '<gold><bold>レジェンダリーロッド'
@@ -756,8 +756,8 @@ gui:
       lore5: '<gold>見せ場になる釣果のための一本です'
       equipped: '<green>✓ 装備中'
       click: '<yellow>▶ クリックして装備'
-      selected: '<green>✓ ロッド tier を Legendary に変更しました。'
-      locked: '<red>✗ Legendary ロッドを使う権限が必要です。'
+      selected: '<green>✓ <gray>レジェンダリーロッドに切り替えました。'
+      locked: '<red>✗ <dark_red>レジェンダリーロッドを使う権限がありません。'
     effects:
       name: '<light_purple><bold>表示演出'
       lore1: '<gray>メニューと釣果演出の'


### PR DESCRIPTION
## Summary
- 6 new docs/developer-api/* child pages: setup, service-access, events, drop-providers, folia-threading, compatibility-policy. developer-api.md is now a just-the-docs parent.
- Japanese rod-select messages now use ティア consistently and read naturally.
- docs/localization/crowdin.md adds the seed-vs-scheduled explanation and the runbook for when a newly enabled target language still shows empty.
- mythicrod-common/src/main/resources/config.yml language comment lists en_GB.

## Live tests today
- Paper RCON: every `/mythicrod config <key> <value>` command persisted to config.yml correctly. Diff against pre-state matches expected state.
- Crowdin seed run `26264410935` imported en_GB + ja_JP after en-GB target was enabled.

## Test plan
- [x] ./gradlew clean build green
- [x] ./gradlew test green (114)
- [x] BundledLocaleParityTest green
- [x] Doc link audit clean

## Summary by Sourcery

Document Developer API usage patterns and clarify localization workflow while refining Japanese in-game text and language configuration metadata.

New Features:
- Add Developer API documentation subpages covering setup, service access, events, external drop providers, Folia threading, and compatibility guarantees.

Enhancements:
- Improve Japanese localization strings for rod tier selection and permissions to use consistent wording and more natural phrasing.
- Clarify language configuration comments to document bundled locales and how to add additional language files.

Documentation:
- Extend Crowdin localization runbook with explanations for the initial seed workflow and troubleshooting newly enabled target languages that show no strings.