### PR TITLE
Live language switch: invalidate open GUI menus

### DIFF
--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
@@ -612,6 +612,12 @@ public class BrigadierCommandManager {
         try {
             config.saveConfig();
             plugin.getLanguageManager().setLanguage(requested);
+            // Force open menus to rebuild against the new locale on next render
+            // and clear any cached per-player tier display strings so the GUI
+            // picks the new translations up immediately.
+            if (plugin.getGUIManager() != null) {
+                plugin.getGUIManager().invalidateOpenMenusForReload();
+            }
             sendMessage(sender, tr(sender, "command.config.language-set",
                 Map.of("locale", requested)));
             playSuccessSound(sender);


### PR DESCRIPTION
## Summary
`/mythicrod config language <locale>` now closes any GUI window currently open on a player so the next reopen renders against the new locale. Without this, the LanguageManager and config.yml updated correctly but already-open menus kept the old strings until restart.

## Test plan
- [x] `./gradlew clean build` (28 tasks, success)
- [x] `./gradlew test` (114 tests, 0 failures)
- [x] Locale parity test still green
- [ ] Live client test: open /mythicrod, switch language with admin command, confirm next open shows new locale

## Summary by Sourcery

New Features:
- Add automatic invalidation of currently open GUI menus when the language configuration is changed via the command.