### PR TITLE
Player-check helper + dev-api rods/stats/examples pages

### DIFF
--- a/docs/developer-api/examples.md
+++ b/docs/developer-api/examples.md
@@ -1,0 +1,129 @@
+---
+title: Examples
+parent: Developer API
+nav_order: 9
+---
+
+# Working examples
+
+Snippets that compile against `mythicrod-api:2026.1.0`.
+
+## VIP loot provider
+
+```java
+import io.xcutiboo.mythicrod.api.ExternalDropProvider;
+import io.xcutiboo.mythicrod.api.MythicRodAPI;
+import io.xcutiboo.mythicrod.api.platform.PlatformItem;
+import io.xcutiboo.mythicrod.api.platform.PlatformPlayer;
+import io.xcutiboo.mythicrod.paper.api.MythicRodServices;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class VipLootPlugin extends JavaPlugin {
+    @Override
+    public void onEnable() {
+        MythicRodServices.find().ifPresent(api ->
+            api.registerExternalDropProvider(new VipReward(api)));
+    }
+
+    @Override
+    public void onDisable() {
+        MythicRodServices.find().ifPresent(api ->
+            api.unregisterExternalDropProvider(VipReward.KEY));
+    }
+}
+
+final class VipReward implements ExternalDropProvider {
+    static final String KEY = "viploot:diamond";
+    private final MythicRodAPI api;
+    VipReward(MythicRodAPI api) { this.api = api; }
+
+    @Override public String getKey() { return KEY; }
+    @Override public String getTier() { return "rare"; }
+    @Override public String getDisplayName() { return "<gold>VIP Diamond"; }
+
+    @Override
+    public double getWeight(PlatformPlayer player) {
+        return player.hasPermission("viploot.vip") ? 4.0D : 0.0D;
+    }
+
+    @Override
+    public PlatformItem generateItem(PlatformPlayer player) {
+        return api.createItem("DIAMOND", 1).orElse(null);
+    }
+}
+```
+
+`paper-plugin.yml`:
+
+```yaml
+name: VipLoot
+main: example.VipLootPlugin
+api-version: '1.21'
+dependencies:
+  server:
+    MythicRod: { load: AFTER, required: false }
+```
+
+## Refresh a leaderboard sign after each catch
+
+```java
+import io.xcutiboo.mythicrod.paper.events.MythicRodStatsUpdateEvent;
+import io.xcutiboo.mythicrod.paper.api.MythicRodServices;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public final class LeaderboardListener implements Listener {
+    private final SignRenderer renderer;
+    public LeaderboardListener(SignRenderer renderer) { this.renderer = renderer; }
+
+    @EventHandler
+    public void onStats(MythicRodStatsUpdateEvent event) {
+        MythicRodServices.find().ifPresent(api ->
+            api.getTopPlayers(
+                io.xcutiboo.mythicrod.api.PlayerStatSnapshot.StatType.TOTAL_CAUGHT, 10)
+            .thenAccept(renderer::queueRefresh));
+    }
+}
+```
+
+`renderer::queueRefresh` must reschedule any Bukkit-touching work onto
+the correct owner thread. See
+[Folia threading]({{ site.baseurl }}/developer-api/folia-threading.html).
+
+## React to the language switch
+
+```java
+import io.xcutiboo.mythicrod.paper.events.MythicRodReloadEvent;
+
+@EventHandler
+public void onReload(MythicRodReloadEvent event) {
+    if (event.isSuccess()) {
+        myCachedTranslations.invalidate();
+    }
+}
+```
+
+The reload event fires both when MythicRod-side reload succeeds and
+when it fails so listeners can clear stale data either way; the
+`isSuccess()` flag lets you target the success path only if that is
+what you need.
+
+## Probe an item's MythicRod tier
+
+```java
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataType;
+
+private static final NamespacedKey CUSTOM_ROD =
+    NamespacedKey.fromString("mythicrod:custom_rod");
+private static final NamespacedKey ROD_TIER =
+    NamespacedKey.fromString("mythicrod:rod_tier");
+
+public Optional<String> rodTier(ItemStack rod) {
+    var pdc = rod.getItemMeta().getPersistentDataContainer();
+    if (!pdc.has(CUSTOM_ROD, PersistentDataType.BYTE)) return Optional.empty();
+    return Optional.ofNullable(pdc.get(ROD_TIER, PersistentDataType.STRING));
+}
+```
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/docs/developer-api/rods.md
+++ b/docs/developer-api/rods.md
@@ -1,0 +1,82 @@
+---
+title: Rods
+parent: Developer API
+nav_order: 7
+---
+
+# Rod identity
+
+MythicRod rods are normal Paper `FISHING_ROD` items with two
+PersistentDataContainer keys:
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `mythicrod:custom_rod` | byte (1) | This item is a MythicRod rod |
+| `mythicrod:rod_tier` | string | One of `basic`, `advanced`, `legendary` |
+
+The display name or lore is never used as identity. A survival player
+cannot rename a vanilla rod into a MythicRod rod.
+
+## Creating a rod from your plugin
+
+If you want to hand out a MythicRod-compatible rod from your own code,
+use the API's item factory instead of building an `ItemStack` by hand.
+That route keeps your rod compatible with future internal changes:
+
+```java
+MythicRodAPI api = MythicRodServices.require();
+ItemStack rod = api.createItem("FISHING_ROD", 1).orElseThrow().toItemStack();
+
+ItemMeta meta = rod.getItemMeta();
+NamespacedKey customRod = NamespacedKey.fromString("mythicrod:custom_rod");
+NamespacedKey rodTier = NamespacedKey.fromString("mythicrod:rod_tier");
+meta.getPersistentDataContainer().set(customRod, PersistentDataType.BYTE, (byte) 1);
+meta.getPersistentDataContainer().set(rodTier, PersistentDataType.STRING, "advanced");
+rod.setItemMeta(meta);
+```
+
+This is rare. Most integrations should hand off to MythicRod's own
+`/mythicrod give` flow or use an `ExternalDropProvider` for tier-aware
+rewards.
+
+## Detecting a MythicRod rod
+
+```java
+NamespacedKey customRod = NamespacedKey.fromString("mythicrod:custom_rod");
+NamespacedKey rodTier = NamespacedKey.fromString("mythicrod:rod_tier");
+
+ItemStack held = player.getInventory().getItemInMainHand();
+PersistentDataContainer pdc = held.getItemMeta().getPersistentDataContainer();
+
+if (pdc.has(customRod, PersistentDataType.BYTE)) {
+    String tier = pdc.get(rodTier, PersistentDataType.STRING);
+    // tier ∈ {basic, advanced, legendary}
+}
+```
+
+## Spoofing limits
+
+- Players cannot write to a foreign plugin's namespace through any
+  vanilla mechanism (anvil, command block, /give NBT, /attribute, etc.).
+- A creative-mode admin with `/give` and raw NBT can craft a spoofed
+  rod. Treat that as a server-trust boundary, not an MythicRod bug.
+- A rod that loses its tier marker (server-side data corruption, manual
+  PDC edit) is treated as the `basic` tier rather than as a custom rod.
+
+## Compatibility with external item plugins
+
+MythicRod rods are still vanilla `FISHING_ROD` items. They can carry
+ItemsAdder/Oraxen/Nexo metadata in their own PDC namespace without
+conflict. MythicRod ignores other namespaces and other plugins ignore
+MythicRod's namespace.
+
+## What not to do
+
+- Do not rely on display name or lore to detect a MythicRod rod.
+  Localised names break that check.
+- Do not edit MythicRod's PDC keys from another plugin. Use
+  `/mythicrod give` or expose your own integration through events.
+- Do not assume the rod is always in main hand. Players may move it to
+  off-hand or armor stand it.
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/docs/developer-api/stats.md
+++ b/docs/developer-api/stats.md
@@ -1,0 +1,87 @@
+---
+title: Stats
+parent: Developer API
+nav_order: 8
+---
+
+# Stats API
+
+MythicRod tracks per-player fishing statistics in
+`plugins/MythicRod/statistics.yml`. Access them through three methods
+on `MythicRodAPI`.
+
+## Read a single player's snapshot
+
+```java
+api.getPlayerStats(player.getUniqueId()).thenAccept(snap -> {
+    long total = snap.totalCaught();
+    int rare = snap.rareCaught();
+    int legendary = snap.legendaryCaught();
+});
+```
+
+`getPlayerStats(UUID)` returns a `CompletableFuture<PlayerStatSnapshot>`.
+For an unknown UUID, the future completes with
+`PlayerStatSnapshot.empty(uuid, "")` rather than failing.
+
+## Leaderboards
+
+```java
+import io.xcutiboo.mythicrod.api.PlayerStatSnapshot.StatType;
+
+api.getTopPlayers(StatType.TOTAL_CAUGHT, 10).thenAccept(top -> {
+    for (PlayerStatSnapshot row : top) {
+        // row.playerName(), row.totalCaught(), row.lastFished()
+    }
+});
+```
+
+| `StatType` | Sort order |
+| --- | --- |
+| `TOTAL_CAUGHT` | total catches, descending |
+| `RARE_CAUGHT` | rare catches, descending |
+| `LEGENDARY_CAUGHT` | legendary catches, descending |
+| `LAST_FISHED` | most-recent catch first |
+
+`limit` is clamped to `1..100`.
+
+## Force a flush
+
+```java
+api.flushAllStats().thenRun(() -> {
+    // Stats are now durable on disk.
+});
+```
+
+Useful right before a backup. MythicRod also flushes automatically on
+plugin shutdown and on the configured cadence
+(`timers.stats-save-interval-seconds`).
+
+## Stat updates as events
+
+If you need a push notification rather than a poll, listen for
+`MythicRodStatsUpdateEvent`. It carries the updated snapshot and the
+catch tier that triggered the update. See
+[events]({{ site.baseurl }}/developer-api/events.html).
+
+## Thread contract
+
+All three methods complete on a MythicRod-owned async thread. Schedule
+back to the right owner before touching Bukkit state. See
+[Folia threading]({{ site.baseurl }}/developer-api/folia-threading.html).
+
+## What `statistics: false` does
+
+When the `features.statistics.enabled` config flag is off:
+
+- Catch events do not increment counters.
+- `MythicRodStatsUpdateEvent` does not fire.
+- `getPlayerStats(...)` and `getTopPlayers(...)` still return whatever
+  was last persisted to disk. They do not error out.
+- `flushAllStats()` is a no-op.
+
+Treat statistics as opt-in for admins. Plugins that rely on them should
+either degrade gracefully or warn the operator when statistics are
+disabled.
+
+[← Developer API]({{ site.baseurl }}/developer-api/)

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
@@ -104,6 +104,18 @@ public class BrigadierCommandManager {
         return plugin.getLanguageManager().tr(key, args);
     }
 
+    /// Returns the sender as a [Player], or null after emitting the standard
+    /// player-only reply and error sound. Use instead of duplicating the
+    /// `sender instanceof Player` block in every player-bound executor.
+    private Player requirePlayer(CommandSender sender) {
+        if (sender instanceof Player player) {
+            return player;
+        }
+        sendMessage(sender, tr(sender, TR_PLAYER_ONLY));
+        playErrorSound(sender);
+        return null;
+    }
+
     public void initialize() {
         LifecycleEventManager<Plugin> manager = plugin.getLifecycleManager();
 
@@ -1529,11 +1541,8 @@ public class BrigadierCommandManager {
     private int executeTestRoll(CommandContext<CommandSourceStack> context) {
         CommandSender sender = context.getSource().getSender();
         try {
-            if (!(sender instanceof Player player)) {
-                sendMessage(sender, tr(sender, TR_PLAYER_ONLY));
-                playErrorSound(sender);
-                return 0;
-            }
+            Player player = requirePlayer(sender);
+            if (player == null) return 0;
 
             String biomeArg = optionalStringArg(context, "biome");
             int count = Math.clamp(optionalIntArg(context, KEY_COUNT, 100), 1, 10000);
@@ -1748,11 +1757,8 @@ public class BrigadierCommandManager {
     private int executeRodSelect(CommandContext<CommandSourceStack> context) {
         CommandSender sender = context.getSource().getSender();
         try {
-            if (!(sender instanceof Player player)) {
-                sendMessage(sender, tr(sender, TR_PLAYER_ONLY));
-                playErrorSound(sender);
-                return 0;
-            }
+            Player player = requirePlayer(sender);
+            if (player == null) return 0;
             String tier = StringArgumentType.getString(context, "tier").toLowerCase(Locale.ROOT);
             String permission = switch (tier) {
                 case TIER_BASIC -> PermissionNodes.GUI;
@@ -1788,11 +1794,8 @@ public class BrigadierCommandManager {
     private int executeRodInspect(CommandContext<CommandSourceStack> context) {
         CommandSender sender = context.getSource().getSender();
         try {
-            if (!(sender instanceof Player player)) {
-                sendMessage(sender, tr(sender, TR_PLAYER_ONLY));
-                playErrorSound(sender);
-                return 0;
-            }
+            Player player = requirePlayer(sender);
+            if (player == null) return 0;
 
             sendMessage(sender, "<gold><st>            </st> <bold>Rod Inspect</bold> <st>            </st>");
             inspectRodSlot(sender, player, EquipmentSlot.HAND, "Main hand");
@@ -1863,11 +1866,8 @@ public class BrigadierCommandManager {
 
     private int executeEffectsToggle(CommandContext<CommandSourceStack> context) {
         CommandSender sender = context.getSource().getSender();
-        if (!(sender instanceof Player player)) {
-            sendMessage(sender, tr(sender, TR_PLAYER_ONLY));
-            playErrorSound(sender);
-            return 0;
-        }
+        Player player = requirePlayer(sender);
+        if (player == null) return 0;
         plugin.getPlayerDataService().toggleReducedEffects(player);
         boolean reduced = plugin.getPlayerDataService().hasReducedEffects(player);
         sendMessage(sender, tr(sender, reduced
@@ -1879,11 +1879,8 @@ public class BrigadierCommandManager {
 
     private int executeEffectsSet(CommandContext<CommandSourceStack> context) {
         CommandSender sender = context.getSource().getSender();
-        if (!(sender instanceof Player player)) {
-            sendMessage(sender, tr(sender, TR_PLAYER_ONLY));
-            playErrorSound(sender);
-            return 0;
-        }
+        Player player = requirePlayer(sender);
+        if (player == null) return 0;
         String mode = StringArgumentType.getString(context, "mode").toLowerCase(Locale.ROOT);
         boolean reduced;
         switch (mode) {


### PR DESCRIPTION
## Summary
- Extract repeated player-only guard into requirePlayer(sender). 5 sites refactored.
- Final dev-api child pages: rods, stats, examples.

## Test plan
- [x] ./gradlew clean build (28 tasks, success)
- [x] ./gradlew test (114 tests, 0 failures)

## Summary by Sourcery

Refactor command handlers to share a common player-only guard and extend the developer API documentation with new rods, stats, and examples pages.

Enhancements:
- Add a reusable requirePlayer helper for command senders and update player-bound executors to use it instead of duplicating checks.

Documentation:
- Add Developer API documentation pages covering rod identity and integration, statistics access and events, and working code examples for common plugin integrations.