### PR TITLE
Minimize the shadow jar

### DIFF
--- a/mythicrod-paper/build.gradle.kts
+++ b/mythicrod-paper/build.gradle.kts
@@ -54,6 +54,11 @@ tasks {
         configurations = listOf(project.configurations.runtimeClasspath.get())
 
         exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+
+        minimize {
+            // Keep bStats; reflection means minimize cannot see the entry points.
+            exclude(dependency("org.bstats:.*:.*"))
+        }
     }
 
     assemble {

--- a/mythicrod-spigot/build.gradle.kts
+++ b/mythicrod-spigot/build.gradle.kts
@@ -30,6 +30,7 @@ tasks {
         archiveClassifier.set("")
         configurations = listOf(project.configurations.runtimeClasspath.get())
         exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+        minimize()
     }
 
     assemble {


### PR DESCRIPTION
Shrinks the bundled jars. bStats kept whole since reflection.

## Summary by Sourcery

Build:
- Configure shadow JAR tasks in paper and spigot modules to run with dependency minimization, excluding bStats from minimization where reflection is used.