### PR TITLE
Trim Crowdin target languages to stay under the free word cap

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -5,9 +5,12 @@ files:
     translation: /mythicrod-paper/src/main/resources/lang/%locale_with_underscore%.yml
     type: yaml
     update_option: update_as_unapproved
+    # Keep target languages under the free 60,000 hosted-word cap.
+    # Source is ~3,920 words, so 10 targets give roughly 39,200 hosted
+    # words (well under the limit). Add a language back when the
+    # source set shrinks or the plan changes.
     languages_mapping:
       locale_with_underscore:
-        en-GB: en_GB
         ja: ja_JP
         de: de_DE
         es-ES: es_ES
@@ -16,9 +19,5 @@ files:
         ru: ru_RU
         zh-CN: zh_CN
         zh-TW: zh_TW
-        nl: nl_NL
         it: it_IT
         ko: ko_KR
-        pl: pl_PL
-        tr: tr_TR
-        uk: uk_UA


### PR DESCRIPTION
Stays under the 60,000 hosted-word limit. Drops en-GB, nl, pl, tr, uk. Comment in crowdin.yml records the math.

## Summary by Sourcery

Limit Crowdin translation targets to stay within the free hosted-word cap by reducing the configured language list and documenting the word-count rationale in the configuration file.

Enhancements:
- Remove several low-priority target locales from Crowdin configuration to reduce hosted-word usage.
- Document hosted-word calculations and conditions for re-adding languages directly in the Crowdin config.