### PR TITLE
Expand stats docs with every snapshot field

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,43 @@
 
 [![Release](https://img.shields.io/github/v/release/xcutiboo/MythicRod?style=flat-square)](https://github.com/xcutiboo/MythicRod/releases) [![Paper 26.1.2](https://img.shields.io/badge/Paper-26.1.2-dca13a?style=flat-square)](https://papermc.io) [![Folia](https://img.shields.io/badge/Folia-region--ready-835516?style=flat-square)](https://papermc.io/software/folia) [![Discord](https://img.shields.io/badge/Discord-chat-5865F2?style=flat-square)](https://discord.gg/MDwtUgxX9U)
 
-Weighted loot tables with biome filters, permission gates, an in-game
+Weighted fishing drops with biome rules, permission gates, an in-game
 drop editor, per-player statistics, and a small public API for Paper
 and Folia.
 
 </div>
 
+<!-- HERO: 1280x640 lake render with a player landing a legendary catch. -->
+<!-- ![Hero](assets/screenshots/hero.png) -->
+
 ## Features
 
 - Weighted drop tables with biome and permission filters
-- In-game GUI editor for drop entries
+- In-game GUI editor for drop entries (live, no reload)
 - Per-player and global statistics plus a leaderboard
 - Three rod tiers (basic / advanced / legendary) gated by permission
 - Folia region-aware schedulers
-- Public Java API for other plugins
-- Crowdin localization (English and Japanese shipped)
+- Public Java API for downstream plugins
+- Crowdin localisation (English and Japanese ship in the jar)
 - Optional Nexo integration for custom items
+
+## Preview
+
+<!-- Screenshots and short clips. PNG for stills, WebM or APNG for motion. -->
+<!-- Suggested sizes: 1280×720 for full screens, 720×480 for tight crops. -->
+<!-- Drop each file into assets/screenshots/ and uncomment the matching line. -->
+
+<!-- Drop editor GUI (live edit, no reload): -->
+<!-- ![Drop editor](assets/screenshots/editor.png) -->
+
+<!-- Catch in action (rare drop landing, particles + sound): -->
+<!-- ![Catch demo](assets/screenshots/catch.gif) -->
+
+<!-- /mythicrod stats and the leaderboard view: -->
+<!-- ![Stats screen](assets/screenshots/stats.png) -->
+
+<!-- /mythicrod drops preview <biome> personalised by viewer perms: -->
+<!-- ![Drops preview command](assets/screenshots/preview.png) -->
 
 ## Quick install
 
@@ -35,5 +56,13 @@ Everything else lives on the docs site:
 - Configuration reference
 - Drop table format
 - Developer API
-- Localization workflow
+- Localisation workflow
 - Release runbook
+
+## Community
+
+- [Discord](https://discord.gg/MDwtUgxX9U) for support and feature
+  discussion.
+- [Crowdin](https://crowdin.com/project/mythicrod) for translations.
+- Issues and pull requests on
+  [GitHub](https://github.com/xcutiboo/MythicRod).

--- a/docs/developer-api/stats.md
+++ b/docs/developer-api/stats.md
@@ -1,81 +1,123 @@
 # Stats API
 
 MythicRod tracks per-player fishing statistics in
-`plugins/MythicRod/statistics.yml`. Access them through three methods
-on `MythicRodAPI`.
+`plugins/MythicRod/statistics.yml`. Three methods on `MythicRodAPI`
+expose them, and every call completes on a MythicRod-owned async
+thread so the main thread is never blocked.
 
-## Read a single player's snapshot
+## What you get back
+
+Each lookup returns a `PlayerStatSnapshot`. It's an immutable Java
+record, safe to pass around and to log. Every field is filled in;
+nothing is `null`.
+
+| Field | Type | What it is |
+| --- | --- | --- |
+| `playerUuid()` | `UUID` | Player identity. Always present. |
+| `playerName()` | `String` | Last name MythicRod saw for this UUID. Empty for unseen players. |
+| `totalCaught()` | `int` | Total custom drops the player has caught. |
+| `commonCaught()` | `int` | Catches that resolved to the `common` tier. |
+| `uncommonCaught()` | `int` | Catches in the `uncommon` tier. |
+| `rareCaught()` | `int` | Catches in the `rare` tier. |
+| `legendaryCaught()` | `int` | Catches in the `legendary` tier. |
+| `basicRodUses()` | `int` | Times the player has cast with a `basic` rod. |
+| `advancedRodUses()` | `int` | Casts with an `advanced` rod. |
+| `legendaryRodUses()` | `int` | Casts with a `legendary` rod. |
+| `lastFished()` | `Instant` | When the player last caught anything. `Instant.EPOCH` if never. |
+| `snapshotTime()` | `Instant` | When this snapshot was taken. |
+
+All counter fields are `>= 0`; the record's constructor rejects
+negative values, so you never have to defend against them.
+
+## Reading a single player
 
 ```java
 api.getPlayerStats(player.getUniqueId()).thenAccept(snap -> {
-    long total = snap.totalCaught();
-    int rare = snap.rareCaught();
-    int legendary = snap.legendaryCaught();
+    int total       = snap.totalCaught();
+    int rare        = snap.rareCaught();
+    int legendary   = snap.legendaryCaught();
+    Instant lastSeen = snap.lastFished();
+    // snap.playerName(), snap.basicRodUses(), etc.
 });
 ```
 
 `getPlayerStats(UUID)` returns a `CompletableFuture<PlayerStatSnapshot>`.
-For an unknown UUID, the future completes with
-`PlayerStatSnapshot.empty(uuid, "")` rather than failing.
+For a UUID MythicRod has never seen, the future completes with
+`PlayerStatSnapshot.empty(uuid, "")` rather than failing, so a missing
+player is the same shape as a zeroed one.
 
 ## Leaderboards
 
 ```java
 import io.xcutiboo.mythicrod.api.PlayerStatSnapshot.StatType;
 
-api.getTopPlayers(StatType.TOTAL_CAUGHT, 10).thenAccept(top -> {
-    for (PlayerStatSnapshot row : top) {
-        // row.playerName(), row.totalCaught(), row.lastFished()
+api.getTopPlayers(StatType.TOTAL_CAUGHT, 10).thenAccept(rows -> {
+    for (PlayerStatSnapshot row : rows) {
+        String name  = row.playerName();
+        int    total = row.totalCaught();
+        Instant when = row.lastFished();
+        // build leaderboard UI from here
     }
 });
 ```
 
-| `StatType` | Sort order |
+| `StatType` value | Sort order |
 | --- | --- |
 | `TOTAL_CAUGHT` | total catches, descending |
-| `RARE_CAUGHT` | rare catches, descending |
-| `LEGENDARY_CAUGHT` | legendary catches, descending |
-| `LAST_FISHED` | most-recent catch first |
+| `RARE_CAUGHT` | rare-tier catches, descending |
+| `LEGENDARY_CAUGHT` | legendary-tier catches, descending |
+| `LAST_FISHED` | most recent activity first |
 
-`limit` is clamped to `1..100`.
+`limit` is clamped to `1..100`. Ask for what you can render; a request
+for `0` or `200` is silently rounded into range, never an error.
 
-## Force a flush
+## Force a flush before a backup
 
 ```java
 api.flushAllStats().thenRun(() -> {
-    // Stats are now durable on disk.
+    // Stats are now durable on disk; safe to snapshot statistics.yml.
 });
 ```
 
-Useful right before a backup. MythicRod also flushes automatically on
-plugin shutdown and on the configured cadence
-(`timers.stats-save-interval-seconds`).
+MythicRod also flushes automatically on plugin shutdown and on the
+configured cadence (`timers.stats-save-interval-seconds`). Manual
+flushes are only useful right before backup snapshots or for tests.
 
-## Stat updates as events
+## Reacting to updates as they happen
 
-If you need a push notification rather than a poll, listen for
-`MythicRodStatsUpdateEvent`. It carries the updated snapshot and the
-catch tier that triggered the update. See
-[events](events.md).
+Polling works, but if you want a push, listen for
+`MythicRodStatsUpdateEvent`. It carries the new snapshot and the tier
+that triggered the change, so you can render leaderboards reactively
+without busy-loops. See [events](events.md).
 
 ## Thread contract
 
-All three methods complete on a MythicRod-owned async thread. Schedule
-back to the right owner before touching Bukkit state. See
-[Folia threading](folia-threading.md).
+Every future completes on a MythicRod-owned async thread. Before
+touching Bukkit state from inside `thenAccept` / `thenRun`, hop back
+to the owner thread:
 
-## What `statistics: false` does
+```java
+api.getPlayerStats(player.getUniqueId()).thenAccept(snap -> {
+    player.getScheduler().run(plugin, task -> {
+        player.sendMessage("You've caught " + snap.totalCaught() + " fish!");
+    }, null);
+});
+```
 
-When the `features.statistics.enabled` config flag is off:
+See [Folia threading](folia-threading.md) for the full table of which
+scheduler owns each Bukkit object.
+
+## When the operator turns statistics off
+
+When `features.statistics.enabled` is set to `false` in config:
 
 - Catch events do not increment counters.
 - `MythicRodStatsUpdateEvent` does not fire.
 - `getPlayerStats(...)` and `getTopPlayers(...)` still return whatever
-  was last persisted to disk. They do not error out.
+  was last persisted to disk; they do not throw.
 - `flushAllStats()` is a no-op.
 
-Treat statistics as opt-in for admins. Plugins that rely on them should
-either degrade gracefully or warn the operator when statistics are
-disabled.
+If your integration depends on live stats, log a friendly notice on
+enable when the flag is off so the admin knows to flip it. Don't crash.
 
 [← Developer API](../developer-api.md)


### PR DESCRIPTION
Documents every PlayerStatSnapshot field with type and meaning. Adds a small scheduler-hop snippet and friendlier framing throughout.

## Summary by Sourcery

Document PlayerStatSnapshot fields and improve high-level Stats API and README guidance for plugin integrators and server admins.

Documentation:
- Expand Stats API docs with a full reference table for all PlayerStatSnapshot fields, including types, invariants, and threading behavior.
- Clarify async thread usage patterns with a concrete scheduler-hop example for safe Bukkit interactions.
- Improve documentation of leaderboard behavior, manual stat flush use cases, and semantics when statistics are disabled in config.
- Refresh README feature descriptions, add guidance for screenshots/previews, and document community/support channels.