### PR TITLE
fix jitpack coord in setup docs

### DIFF
--- a/docs/developer-api/setup.md
+++ b/docs/developer-api/setup.md
@@ -15,12 +15,16 @@ repositories {
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:26.1.2.build.64-stable")
-    compileOnly("com.github.xcutiboo.MythicRod:mythicrod-api:v2026.1.0")
+    // JitPack treats the api module as the project artifact, so pin
+    // the repo not a submodule. Available from v2026.1.1 onwards.
+    compileOnly("com.github.xcutiboo:MythicRod:v2026.1.1")
 }
 ```
 
-The first build for a new MythicRod tag triggers a one-time JitPack
-build (1-5 minutes). Subsequent consumers get the cached artifact.
+The first resolution for a new MythicRod tag triggers a one-time
+JitPack build (1-5 minutes). Subsequent consumers get the cached
+artifact. For development you can also pin
+`com.github.xcutiboo:MythicRod:master-SNAPSHOT`.
 
 ## Gradle (Kotlin DSL) - jar drop
 


### PR DESCRIPTION
Coord path was wrong - api goes under repo root, not as submodule.

## Summary by Sourcery

Correct JitPack coordinates and usage guidance for the MythicRod API in the developer setup documentation.

Documentation:
- Update Gradle dependency coordinates to reference the root MythicRod repository artifact instead of a submodule in JitPack setup docs.
- Clarify JitPack build behavior and document the option to depend on the master-SNAPSHOT for development.