### PR TITLE
polymart api_key in query string too

### DIFF
--- a/.github/workflows/publish-polymart.yml
+++ b/.github/workflows/publish-polymart.yml
@@ -104,7 +104,7 @@ jobs:
           if [[ -z "$message" ]]; then
             message="See https://github.com/xcutiboo/MythicRod/releases/tag/v${VERSION}"
           fi
-          response=$(curl -fsS -X POST "https://api.polymart.org/v1/postUpdate" \
+          response=$(curl -fsS -X POST "https://api.polymart.org/v1/postUpdate?api_key=${POLYMART_API_TOKEN}" \
             -F "api_key=${POLYMART_API_TOKEN}" \
             -F "resource_id=${POLYMART_RESOURCE_ID}" \
             -F "version=${VERSION}" \


### PR DESCRIPTION
Polymart rejected multipart-only key. Pass it in query too.

## Summary by Sourcery

CI:
- Adjust the Polymart publish GitHub Actions workflow to append the API key as a query parameter to the postUpdate API call.