### PR TITLE
throttle helix to once per 4 seconds per player

### DIFF
--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/util/TierVisualEffects.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/util/TierVisualEffects.java
@@ -1,6 +1,9 @@
 package io.xcutiboo.mythicrod.paper.util;
 
 import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.bukkit.Color;
@@ -37,6 +40,13 @@ public final class TierVisualEffects {
     private static final int   HELIX_POINTS     = 3;    // particles per tick.
     private static final double HELIX_RADIUS    = 0.7;
     private static final double HELIX_LIFT      = 0.12; // y rise per tick.
+    private static final long  HELIX_COOLDOWN_MS = 4_000L;
+
+    /// Per-player timestamp of the last helix animation. Used to throttle
+    /// the heavy cue so back-to-back legendary catches don't bury one
+    /// celebration under the next. The map is bounded by online-player
+    /// count and entries naturally fall out of relevance after logout.
+    private static final Map<UUID, Long> LAST_HELIX = new ConcurrentHashMap<>();
 
     private TierVisualEffects() {
     }
@@ -52,14 +62,31 @@ public final class TierVisualEffects {
             case "rare"     -> rare(player, at);
             case "legendary" -> {
                 legendaryBurst(player, at);
-                helix(plugin, player, LEGENDARY, MYTHIC);
+                if (claimHelixSlot(player)) {
+                    helix(plugin, player, LEGENDARY, MYTHIC);
+                }
             }
             case "mythic", "mythical" -> {
                 mythicBurst(player, at);
-                helix(plugin, player, MYTHIC, COMMON);
+                if (claimHelixSlot(player)) {
+                    helix(plugin, player, MYTHIC, COMMON);
+                }
             }
             default -> common(player, at);
         }
+    }
+
+    /// Returns true at most once per HELIX_COOLDOWN_MS per player.
+    /// Throttles the heavy cue so back-to-back top-tier catches do
+    /// not pile helix animations on top of each other.
+    private static boolean claimHelixSlot(Player player) {
+        long now = System.currentTimeMillis();
+        Long previous = LAST_HELIX.get(player.getUniqueId());
+        if (previous != null && now - previous < HELIX_COOLDOWN_MS) {
+            return false;
+        }
+        LAST_HELIX.put(player.getUniqueId(), now);
+        return true;
     }
 
     private static void common(Player player, Location at) {


### PR DESCRIPTION
Per-player rate limit on the helix animation. Back-to-back top-tier catches still get the burst.

## Summary by Sourcery

Throttle the per-player legendary/mythic helix particle animation to reduce visual and performance load while preserving the immediate burst effects for top-tier catches.

Enhancements:
- Introduce a per-player, time-based cooldown for the helix animation so repeated top-tier catches do not stack overlapping helices.
- Add a scheduled rising-helix particle effect for legendary and mythic catches that runs briefly on the player’s scheduler thread.
- Update the catch effect API to require a plugin reference when triggering tier-based visual effects.