### PR TITLE
feat(api): preview eligible drops by player + biome

### DIFF
--- a/docs/developer-api/examples.md
+++ b/docs/developer-api/examples.md
@@ -120,4 +120,38 @@ public Optional<String> rodTier(ItemStack rod) {
 }
 ```
 
+## Minigame: "what could I catch here?" preview
+
+`previewEligibleDrops(UUID, biomeKey)` returns the drop table after
+biome and permission filters. Use it in tutorial overlays, fishing
+spot UIs, or scoreboard tickers without running an actual catch.
+
+```java
+import io.xcutiboo.mythicrod.api.MythicRodAPI;
+import io.xcutiboo.mythicrod.api.platform.PlatformDrop;
+import io.xcutiboo.mythicrod.paper.api.MythicRodServices;
+import org.bukkit.entity.Player;
+
+public void showPreview(Player player) {
+    String biomeKey = player.getWorld()
+        .getBiome(player.getLocation())
+        .getKey()
+        .toString();
+
+    MythicRodServices.find().ifPresent(api -> {
+        var eligible = api.previewEligibleDrops(player.getUniqueId(), biomeKey);
+        int total = eligible.stream().mapToInt(PlatformDrop::getWeight).sum();
+        eligible.forEach(drop -> {
+            double share = total == 0 ? 0.0 : (drop.getWeight() * 100.0 / total);
+            player.sendMessage("§7- " + drop.getIdentifier()
+                + " §8(" + String.format("%.1f", share) + "%§8)");
+        });
+    });
+}
+```
+
+Pass `null` as the biome to ignore biome filters. The list is an
+immutable snapshot; reloads do not retroactively change a returned
+list. Available since `2026.2.0`.
+
 [← Developer API](../developer-api.md)

--- a/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/MythicRodAPI.java
+++ b/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/MythicRodAPI.java
@@ -10,8 +10,11 @@ import org.jetbrains.annotations.NotNull;
 
 import io.xcutiboo.mythicrod.api.PlayerStatSnapshot.StatType;
 import io.xcutiboo.mythicrod.api.drop.DropCatalog;
+import io.xcutiboo.mythicrod.api.platform.PlatformDrop;
 import io.xcutiboo.mythicrod.api.platform.PlatformItem;
 import io.xcutiboo.mythicrod.api.platform.PlatformItemFactory;
+
+import org.jetbrains.annotations.Nullable;
 
 /// Public integration contract for MythicRod.
 ///
@@ -144,6 +147,29 @@ public interface MythicRodAPI {
             @NotNull StatType statType,
             int limit
     );
+
+    /// Returns the drops the given online player would be eligible to roll at
+    /// the given biome, after biome filters and permission filters are applied.
+    ///
+    /// Returns an empty list when the player is offline or no drops are
+    /// eligible. The returned list is an immutable snapshot of the current
+    /// drop table - subsequent reloads do not retroactively change it.
+    ///
+    /// Intended for minigame UIs, tutorial overlays, and "what could I catch
+    /// here?" inspections. The actual roll is still resolved at catch time and
+    /// can be biased or replaced by `MythicRodRewardRollEvent`.
+    ///
+    /// @param playerId UUID of the player to check eligibility for. Must
+    ///                 belong to a currently-online player.
+    /// @param biomeKey Biome key such as `"minecraft:ocean"`, or `null` to
+    ///                 ignore biome filters.
+    /// @return immutable list of eligible drops. Empty when the player is
+    ///         offline or has no eligible drops.
+    @ApiStatus.AvailableSince("2026.2.0")
+    @NotNull
+    List<? extends PlatformDrop> previewEligibleDrops(
+            @NotNull UUID playerId,
+            @Nullable String biomeKey);
 
     /// Flushes all in-memory player statistics to persistent storage.
     ///

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPI.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPI.java
@@ -18,14 +18,19 @@ import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
 import io.xcutiboo.mythicrod.api.ExternalDropProvider;
 import io.xcutiboo.mythicrod.api.MythicRodAPI;
 import io.xcutiboo.mythicrod.api.PlayerStatSnapshot;
 import io.xcutiboo.mythicrod.api.drop.DropCatalog;
+import io.xcutiboo.mythicrod.api.platform.PlatformDrop;
 import io.xcutiboo.mythicrod.api.platform.PlatformItem;
 import io.xcutiboo.mythicrod.api.platform.PlatformItemFactory;
 import io.xcutiboo.mythicrod.api.platform.PlatformPlayer;
 import io.xcutiboo.mythicrod.api.platform.PlatformScheduler;
+import io.xcutiboo.mythicrod.paper.platform.PaperPlayer;
 import io.xcutiboo.mythicrod.drops.CustomDrop;
 import io.xcutiboo.mythicrod.drops.DropConfigurationRecord;
 import io.xcutiboo.mythicrod.drops.DropManager;
@@ -136,6 +141,18 @@ public class PaperMythicRodAPI implements MythicRodAPI {
     @NotNull
     public List<ExternalDropProvider> getExternalDropProviders() {
         return List.copyOf(externalProviders.values());
+    }
+
+    @Override
+    @NotNull
+    public List<? extends PlatformDrop> previewEligibleDrops(
+            @NotNull UUID playerId,
+            @Nullable String biomeKey) {
+        Player bukkitPlayer = Bukkit.getPlayer(playerId);
+        if (bukkitPlayer == null) {
+            return List.of();
+        }
+        return List.copyOf(dropManager.getEligibleDrops(new PaperPlayer(bukkitPlayer), biomeKey));
     }
 
     public double getBaseRewardWeight(@NotNull PlatformPlayer player, @Nullable String biomeName) {


### PR DESCRIPTION
Adds `MythicRodAPI.previewEligibleDrops(UUID, biomeKey)` so minigame plugins can show 'what could I catch here' without firing a catch. Reuses the existing eligibility filter; new public method only. Marked AvailableSince 2026.2.0; release-please will mint that on next feat-bumped release.

## Summary by Sourcery

Expose a new API for previewing eligible fishing drops for a given player and biome, with a Paper implementation and usage example documentation.

New Features:
- Add MythicRodAPI.previewEligibleDrops(UUID playerId, String biomeKey) to return the current eligible drops for an online player at a given biome, ignoring biome filters when biomeKey is null.

Documentation:
- Document the new previewEligibleDrops API with an example showing how to display catch probability previews in minigame and UI contexts.