### PR TITLE
import the FQNs we kept inlining

### DIFF
--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/ConfigMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/ConfigMenu.java
@@ -7,6 +7,7 @@ import java.util.logging.Level;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.xcutiboo.mythicrod.paper.MythicRod;
@@ -158,7 +159,7 @@ public class ConfigMenu extends BaseMenu {
         });
     }
 
-    private void cycleParticleForEvent(org.bukkit.event.inventory.InventoryClickEvent event) {
+    private void cycleParticleForEvent(InventoryClickEvent event) {
         boolean shift = event.isShiftClick();
         boolean right = event.isRightClick();
         if (shift && !right) {
@@ -281,7 +282,7 @@ public class ConfigMenu extends BaseMenu {
         return tr("gui.config.save_interval.infrequent");
     }
 
-    private int nextStatsInterval(int current, org.bukkit.event.inventory.InventoryClickEvent event) {
+    private int nextStatsInterval(int current, InventoryClickEvent event) {
         int change = event.isShiftClick() ? 300 : 60;
         if (event.isLeftClick()) return Math.min(3600, current + change);
         if (event.isRightClick()) return Math.max(60, current - change);

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/MainHubMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/MainHubMenu.java
@@ -1,9 +1,11 @@
 package io.xcutiboo.mythicrod.paper.gui.menus;
 
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.xcutiboo.mythicrod.paper.MythicRod;
@@ -147,7 +149,7 @@ public class MainHubMenu extends BaseMenu {
         setItem(33, item, this::onReloadClick);
     }
 
-    private void onReloadClick(org.bukkit.event.inventory.InventoryClickEvent event) {
+    private void onReloadClick(InventoryClickEvent event) {
         if (!event.isShiftClick()) {
             playErrorSound();
             sendMessage(tr("gui.main.reload_confirm"));
@@ -168,7 +170,7 @@ public class MainHubMenu extends BaseMenu {
         } catch (Exception e) {
             playErrorSound();
             sendMessage(tr("gui.main.reload_failed"));
-            plugin.getLogger().log(java.util.logging.Level.SEVERE, "Error reloading from GUI", e);
+            plugin.getLogger().log(Level.SEVERE, "Error reloading from GUI", e);
         }
     }
 

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/ItemBuilder.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/ItemBuilder.java
@@ -2,6 +2,7 @@ package io.xcutiboo.mythicrod.paper.item;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.bukkit.Material;
@@ -137,7 +138,7 @@ public class ItemBuilder {
                                        Registry<Enchantment> registry,
                                        Map.Entry<String, Integer> entry) {
         if (entry.getKey() == null || entry.getValue() == null) return;
-        String enchantName = entry.getKey().toLowerCase(java.util.Locale.ROOT);
+        String enchantName = entry.getKey().toLowerCase(Locale.ROOT);
         NamespacedKey key = enchantName.contains(":")
             ? NamespacedKey.fromString(enchantName)
             : NamespacedKey.minecraft(enchantName);

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/RodFactory.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/RodFactory.java
@@ -1,6 +1,7 @@
 package io.xcutiboo.mythicrod.paper.item;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -121,6 +122,6 @@ public class RodFactory {
         double multiplier = plugin.getConfigManager() != null
             ? plugin.getConfigManager().getRodLuckMultiplier(tier)
             : 1.0D;
-        return String.format(java.util.Locale.ROOT, "%.2f", multiplier);
+        return String.format(Locale.ROOT, "%.2f", multiplier);
     }
 }

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/platform/PaperLocation.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/platform/PaperLocation.java
@@ -1,6 +1,8 @@
 package io.xcutiboo.mythicrod.paper.platform;
 
 import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
 
 import io.xcutiboo.mythicrod.api.platform.PlatformLocation;
 
@@ -24,11 +26,11 @@ public final class PaperLocation {
         );
     }
 
-    public static Location toBukkit(PlatformLocation platformLocation, org.bukkit.Server server) {
+    public static Location toBukkit(PlatformLocation platformLocation, Server server) {
         if (platformLocation == null) {
             return null;
         }
-        org.bukkit.World world = server.getWorld(platformLocation.getWorldName());
+        World world = server.getWorld(platformLocation.getWorldName());
         if (world == null) {
             return null;
         }

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/platform/PaperWorld.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/platform/PaperWorld.java
@@ -1,5 +1,6 @@
 package io.xcutiboo.mythicrod.paper.platform;
 
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
 
@@ -23,7 +24,7 @@ public class PaperWorld implements PlatformWorld {
     public void dropItem(PlatformLocation location, PlatformItem item) {
         if (location == null || item == null) return;
         
-        org.bukkit.Location bukkitLoc = new org.bukkit.Location(
+        Location bukkitLoc = new Location(
             world,
             location.getX(), location.getY(), location.getZ(),
             location.getYaw(), location.getPitch()

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/scheduler/FoliaSchedulerService.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/scheduler/FoliaSchedulerService.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -58,7 +59,7 @@ public class FoliaSchedulerService implements PlatformScheduler {
             try {
                 task.cancel();
             } catch (RuntimeException e) {
-                plugin.getLogger().log(java.util.logging.Level.WARNING,
+                plugin.getLogger().log(Level.WARNING,
                     "Failed to cancel a scheduled MythicRod task", e);
             }
         }


### PR DESCRIPTION
Pulled six inline FQNs (Locale, Level, Location, Server, World, InventoryClickEvent) up to imports. Pure style cleanup; no behavior change.

## Summary by Sourcery

Simplify Bukkit and Java API usage by replacing fully qualified class names with imported types across GUI, platform, item, and scheduler classes.

Enhancements:
- Use imported types instead of fully qualified names for Bukkit event, location, world, and server classes.
- Use imported types instead of fully qualified java.util.Locale and java.util.logging.Level constants for logging and formatting.