### PR TITLE
feat(api): createRod(tier) helper

### DIFF
--- a/docs/developer-api/rods.md
+++ b/docs/developer-api/rods.md
@@ -13,9 +13,23 @@ cannot rename a vanilla rod into a MythicRod rod.
 
 ## Creating a rod from your plugin
 
-If you want to hand out a MythicRod-compatible rod from your own code,
-use the API's item factory instead of building an `ItemStack` by hand.
-That route keeps your rod compatible with future internal changes:
+The cleanest path is `MythicRodAPI.createRod(tier)`. It returns the
+fully-tagged rod with display name, lore, glow, and unbreakable flag
+matching MythicRod's built-in presets. Available since `2026.2.0`.
+
+```java
+MythicRodAPI api = MythicRodServices.require();
+PlatformItem rod = api.createRod("advanced").orElseThrow();
+player.getInventory().addItem(((PaperPlatformItem) rod).getItemStack());
+```
+
+Valid tiers (case-insensitive): `basic`, `advanced`, `legendary`. An
+unknown tier returns a `Result.failure` rather than throwing.
+
+### Manual rod creation (legacy path)
+
+If you need to override the preset, build the rod through the item
+factory and write the PDC keys yourself:
 
 ```java
 MythicRodAPI api = MythicRodServices.require();
@@ -29,9 +43,8 @@ meta.getPersistentDataContainer().set(rodTier, PersistentDataType.STRING, "advan
 rod.setItemMeta(meta);
 ```
 
-This is rare. Most integrations should hand off to MythicRod's own
-`/mythicrod give` flow or use an `ExternalDropProvider` for tier-aware
-rewards.
+Reach for the manual path only when the built-in preset does not fit;
+otherwise prefer `createRod(tier)`.
 
 ## Detecting a MythicRod rod
 

--- a/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/MythicRodAPI.java
+++ b/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/MythicRodAPI.java
@@ -148,6 +148,24 @@ public interface MythicRodAPI {
             int limit
     );
 
+    /// Creates a MythicRod fishing rod of the given tier, fully tagged with
+    /// MythicRod's PDC marker and tier metadata so the catch listener and
+    /// statistics pipeline pick it up.
+    ///
+    /// Valid tier names are `"basic"`, `"advanced"`, and `"legendary"`, matched
+    /// case-insensitively. The rod's display name, lore, glow, and unbreakable
+    /// flag follow MythicRod's built-in presets for that tier.
+    ///
+    /// Prefer this over building an `ItemStack` and writing PDC keys by hand:
+    /// future internal changes to the rod marker stay invisible to the caller.
+    ///
+    /// @param tier `"basic"`, `"advanced"`, or `"legendary"` (case-insensitive).
+    /// @return success result with the tagged rod, or failure when the tier is
+    ///         unknown.
+    @ApiStatus.AvailableSince("2026.2.0")
+    @NotNull
+    Result<PlatformItem> createRod(@NotNull String tier);
+
     /// Returns the drops the given online player would be eligible to roll at
     /// the given biome, after biome filters and permission filters are applied.
     ///

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/MythicRod.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/MythicRod.java
@@ -22,6 +22,7 @@ import io.xcutiboo.mythicrod.config.LanguageManager;
 import io.xcutiboo.mythicrod.drops.DropManager;
 import io.xcutiboo.mythicrod.internal.runtime.MythicRodRuntime;
 import io.xcutiboo.mythicrod.metrics.StatisticsManager;
+import io.xcutiboo.mythicrod.paper.item.RodFactory;
 import io.xcutiboo.mythicrod.paper.api.PaperMythicRodAPI;
 import io.xcutiboo.mythicrod.paper.commands.BrigadierCommandManager;
 import io.xcutiboo.mythicrod.paper.data.PlayerDataService;
@@ -167,7 +168,8 @@ public final class MythicRod extends JavaPlugin implements MythicRodRuntime {
             dropManager,
             statisticsManager,
             platformScheduler,
-            platformServer.getItemFactory()
+            platformServer.getItemFactory(),
+            new RodFactory(this)
         );
         // Bukkit ServicesManager registration lets third-party plugins resolve
         // the API without compile-time dependency on our internal classes.

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPI.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPI.java
@@ -20,16 +20,20 @@ import org.jetbrains.annotations.Nullable;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import io.xcutiboo.mythicrod.api.ExternalDropProvider;
 import io.xcutiboo.mythicrod.api.MythicRodAPI;
 import io.xcutiboo.mythicrod.api.PlayerStatSnapshot;
+import io.xcutiboo.mythicrod.api.Result;
 import io.xcutiboo.mythicrod.api.drop.DropCatalog;
 import io.xcutiboo.mythicrod.api.platform.PlatformDrop;
 import io.xcutiboo.mythicrod.api.platform.PlatformItem;
 import io.xcutiboo.mythicrod.api.platform.PlatformItemFactory;
 import io.xcutiboo.mythicrod.api.platform.PlatformPlayer;
 import io.xcutiboo.mythicrod.api.platform.PlatformScheduler;
+import io.xcutiboo.mythicrod.paper.item.RodFactory;
+import io.xcutiboo.mythicrod.paper.platform.PaperItem;
 import io.xcutiboo.mythicrod.paper.platform.PaperPlayer;
 import io.xcutiboo.mythicrod.drops.CustomDrop;
 import io.xcutiboo.mythicrod.drops.DropConfigurationRecord;
@@ -67,6 +71,7 @@ public class PaperMythicRodAPI implements MythicRodAPI {
     private final StatisticsManager statisticsManager;
     private final PlatformScheduler scheduler;
     private final PlatformItemFactory itemFactory;
+    private final RodFactory rodFactory;
 
     private final ConcurrentHashMap<String, ExternalDropProvider> externalProviders =
             new ConcurrentHashMap<>();
@@ -77,13 +82,15 @@ public class PaperMythicRodAPI implements MythicRodAPI {
             @NotNull DropManager dropManager,
             @NotNull StatisticsManager statisticsManager,
             @NotNull PlatformScheduler scheduler,
-            @NotNull PlatformItemFactory itemFactory) {
+            @NotNull PlatformItemFactory itemFactory,
+            @NotNull RodFactory rodFactory) {
         this.version = version;
         this.logger = logger;
         this.dropManager = dropManager;
         this.statisticsManager = statisticsManager;
         this.scheduler = scheduler;
         this.itemFactory = itemFactory;
+        this.rodFactory = rodFactory;
     }
 
     /// Internal reward-selection result used by the Paper fishing pipeline.
@@ -141,6 +148,21 @@ public class PaperMythicRodAPI implements MythicRodAPI {
     @NotNull
     public List<ExternalDropProvider> getExternalDropProviders() {
         return List.copyOf(externalProviders.values());
+    }
+
+    @Override
+    @NotNull
+    public Result<PlatformItem> createRod(@NotNull String tier) {
+        ItemStack rod = switch (tier.toLowerCase(Locale.ROOT)) {
+            case "basic" -> rodFactory.createBasicRod();
+            case "advanced" -> rodFactory.createAdvancedRod();
+            case "legendary" -> rodFactory.createLegendaryRod();
+            default -> null;
+        };
+        if (rod == null) {
+            return Result.failure("Unknown rod tier '" + tier + "'. Valid tiers: basic, advanced, legendary.");
+        }
+        return Result.success(new PaperItem(rod));
     }
 
     @Override

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/ConfigMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/ConfigMenu.java
@@ -7,6 +7,7 @@ import java.util.logging.Level;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.xcutiboo.mythicrod.paper.MythicRod;
@@ -158,7 +159,7 @@ public class ConfigMenu extends BaseMenu {
         });
     }
 
-    private void cycleParticleForEvent(org.bukkit.event.inventory.InventoryClickEvent event) {
+    private void cycleParticleForEvent(InventoryClickEvent event) {
         boolean shift = event.isShiftClick();
         boolean right = event.isRightClick();
         if (shift && !right) {
@@ -281,7 +282,7 @@ public class ConfigMenu extends BaseMenu {
         return tr("gui.config.save_interval.infrequent");
     }
 
-    private int nextStatsInterval(int current, org.bukkit.event.inventory.InventoryClickEvent event) {
+    private int nextStatsInterval(int current, InventoryClickEvent event) {
         int change = event.isShiftClick() ? 300 : 60;
         if (event.isLeftClick()) return Math.min(3600, current + change);
         if (event.isRightClick()) return Math.max(60, current - change);

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/MainHubMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/MainHubMenu.java
@@ -1,9 +1,11 @@
 package io.xcutiboo.mythicrod.paper.gui.menus;
 
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.xcutiboo.mythicrod.paper.MythicRod;
@@ -147,7 +149,7 @@ public class MainHubMenu extends BaseMenu {
         setItem(33, item, this::onReloadClick);
     }
 
-    private void onReloadClick(org.bukkit.event.inventory.InventoryClickEvent event) {
+    private void onReloadClick(InventoryClickEvent event) {
         if (!event.isShiftClick()) {
             playErrorSound();
             sendMessage(tr("gui.main.reload_confirm"));
@@ -168,7 +170,7 @@ public class MainHubMenu extends BaseMenu {
         } catch (Exception e) {
             playErrorSound();
             sendMessage(tr("gui.main.reload_failed"));
-            plugin.getLogger().log(java.util.logging.Level.SEVERE, "Error reloading from GUI", e);
+            plugin.getLogger().log(Level.SEVERE, "Error reloading from GUI", e);
         }
     }
 

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/ItemBuilder.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/ItemBuilder.java
@@ -2,6 +2,7 @@ package io.xcutiboo.mythicrod.paper.item;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.bukkit.Material;
@@ -137,7 +138,7 @@ public class ItemBuilder {
                                        Registry<Enchantment> registry,
                                        Map.Entry<String, Integer> entry) {
         if (entry.getKey() == null || entry.getValue() == null) return;
-        String enchantName = entry.getKey().toLowerCase(java.util.Locale.ROOT);
+        String enchantName = entry.getKey().toLowerCase(Locale.ROOT);
         NamespacedKey key = enchantName.contains(":")
             ? NamespacedKey.fromString(enchantName)
             : NamespacedKey.minecraft(enchantName);

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/RodFactory.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/RodFactory.java
@@ -1,6 +1,7 @@
 package io.xcutiboo.mythicrod.paper.item;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -121,6 +122,6 @@ public class RodFactory {
         double multiplier = plugin.getConfigManager() != null
             ? plugin.getConfigManager().getRodLuckMultiplier(tier)
             : 1.0D;
-        return String.format(java.util.Locale.ROOT, "%.2f", multiplier);
+        return String.format(Locale.ROOT, "%.2f", multiplier);
     }
 }

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/platform/PaperLocation.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/platform/PaperLocation.java
@@ -1,6 +1,8 @@
 package io.xcutiboo.mythicrod.paper.platform;
 
 import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
 
 import io.xcutiboo.mythicrod.api.platform.PlatformLocation;
 
@@ -24,11 +26,11 @@ public final class PaperLocation {
         );
     }
 
-    public static Location toBukkit(PlatformLocation platformLocation, org.bukkit.Server server) {
+    public static Location toBukkit(PlatformLocation platformLocation, Server server) {
         if (platformLocation == null) {
             return null;
         }
-        org.bukkit.World world = server.getWorld(platformLocation.getWorldName());
+        World world = server.getWorld(platformLocation.getWorldName());
         if (world == null) {
             return null;
         }

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/platform/PaperWorld.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/platform/PaperWorld.java
@@ -1,5 +1,6 @@
 package io.xcutiboo.mythicrod.paper.platform;
 
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
 
@@ -23,7 +24,7 @@ public class PaperWorld implements PlatformWorld {
     public void dropItem(PlatformLocation location, PlatformItem item) {
         if (location == null || item == null) return;
         
-        org.bukkit.Location bukkitLoc = new org.bukkit.Location(
+        Location bukkitLoc = new Location(
             world,
             location.getX(), location.getY(), location.getZ(),
             location.getYaw(), location.getPitch()

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/scheduler/FoliaSchedulerService.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/scheduler/FoliaSchedulerService.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -58,7 +59,7 @@ public class FoliaSchedulerService implements PlatformScheduler {
             try {
                 task.cancel();
             } catch (RuntimeException e) {
-                plugin.getLogger().log(java.util.logging.Level.WARNING,
+                plugin.getLogger().log(Level.WARNING,
                     "Failed to cancel a scheduled MythicRod task", e);
             }
         }

--- a/mythicrod-paper/src/test/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPICreateRodTest.java
+++ b/mythicrod-paper/src/test/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPICreateRodTest.java
@@ -1,0 +1,45 @@
+package io.xcutiboo.mythicrod.paper.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.xcutiboo.mythicrod.api.Result;
+import io.xcutiboo.mythicrod.api.platform.PlatformItem;
+
+class PaperMythicRodAPICreateRodTest {
+
+    @Test
+    void unknownTierReturnsFailureBeforeTouchingFactory() {
+        PaperMythicRodAPI api = new PaperMythicRodAPI(
+            "test-version",
+            java.util.logging.Logger.getAnonymousLogger(),
+            null, null, null, null, null
+        );
+
+        Result<PlatformItem> result = api.createRod("god-tier");
+
+        assertNotNull(result);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Unknown rod tier"));
+        assertTrue(result.getError().contains("basic"));
+        assertTrue(result.getError().contains("advanced"));
+        assertTrue(result.getError().contains("legendary"));
+    }
+
+    @Test
+    void unknownTierIsCaseInsensitiveOnTheReportedInput() {
+        PaperMythicRodAPI api = new PaperMythicRodAPI(
+            "test-version",
+            java.util.logging.Logger.getAnonymousLogger(),
+            null, null, null, null, null
+        );
+
+        Result<PlatformItem> result = api.createRod("MYTHIC");
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("MYTHIC"));
+    }
+}


### PR DESCRIPTION
One-call rod creation for minigame plugins. Replaces the manual PDC-key path with `api.createRod("advanced").orElseThrow()`. Marked AvailableSince 2026.2.0.

## Summary by Sourcery

Add a high-level API helper to create fully tagged MythicRod fishing rods by tier and update documentation to recommend it over manual PDC-based construction.

New Features:
- Expose MythicRodAPI.createRod(tier) to create fully tagged fishing rods for the basic, advanced, and legendary tiers, returning a Result instead of throwing on unknown tiers.

Enhancements:
- Wire the Paper implementation to a RodFactory for tiered rod creation and simplify various Bukkit-related type references and logging calls.

Documentation:
- Update developer API documentation to describe the new createRod(tier) helper, valid tiers, and when to prefer it over manual rod construction.

Tests:
- Add unit tests covering createRod(tier) failure behavior and error messaging for unknown tiers.