### PR TITLE
more sonar-flagged cleanup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,12 +30,14 @@ jobs:
           python-version: '3.12'
 
       - name: Install MkDocs Material
+        # Pin exact versions and force binary wheels: Sonar S8544/S8541
+        # (unpinned dependencies + setup-script execution risk).
         run: |
           python -m pip install --upgrade pip
-          pip install \
-            "mkdocs-material>=9.5" \
-            "mkdocs-static-i18n>=1.2" \
-            "mkdocs-git-revision-date-localized-plugin>=1.2"
+          pip install --only-binary :all: \
+            "mkdocs-material==9.5.45" \
+            "mkdocs-static-i18n==1.2.3" \
+            "mkdocs-git-revision-date-localized-plugin==1.2.9"
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/MythicRodAPI.java
+++ b/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/MythicRodAPI.java
@@ -185,6 +185,9 @@ public interface MythicRodAPI {
     ///         offline or has no eligible drops.
     @ApiStatus.AvailableSince("2026.2.0")
     @NotNull
+    @SuppressWarnings("java:S1452")
+    // The wildcard mirrors DropCatalog#getDrops so MythicRod can return its
+    // concrete CustomDrop list without forcing a defensive copy on every call.
     List<? extends PlatformDrop> previewEligibleDrops(
             @NotNull UUID playerId,
             @Nullable String biomeKey);

--- a/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/package-info.java
+++ b/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/package-info.java
@@ -6,7 +6,7 @@
 /// {@link io.xcutiboo.mythicrod.api.drop.DropCatalog}. Platform-neutral value
 /// types live in {@link io.xcutiboo.mythicrod.api.platform}.
 ///
-/// The Paper runtime publishes {@code MythicRodAPI} through Bukkit's
-/// {@code ServicesManager}. Future-backed methods complete on MythicRod-owned
+/// The Paper runtime publishes `MythicRodAPI` through Bukkit's
+/// `ServicesManager`. Future-backed methods complete on MythicRod-owned
 /// async threads and must be rescheduled before touching platform state.
 package io.xcutiboo.mythicrod.api;

--- a/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/constants/PermissionNodes.java
+++ b/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/constants/PermissionNodes.java
@@ -1,6 +1,6 @@
 package io.xcutiboo.mythicrod.constants;
 
-/// Permission node constants mirrored in {@code paper-plugin.yml}.
+/// Permission node constants mirrored in `paper-plugin.yml`.
 public final class PermissionNodes {
     private PermissionNodes() {}
 

--- a/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/drops/DropManager.java
+++ b/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/drops/DropManager.java
@@ -25,12 +25,12 @@ import lombok.NonNull;
 
 /// Manages fishing drop tables loaded from configuration.
 ///
-/// <strong>Thread safety:</strong> The canonical drop table is held in an
+/// **Thread safety:** The canonical drop table is held in an
 /// {@link AtomicReference} so that a reload (which builds a completely new map)
 /// is published atomically. Readers always see either the old complete map or
 /// the new complete map, never a partially-populated one. Individual category
 /// lists use {@link CopyOnWriteArrayList} so that in-place mutations
-/// ({@code updateDrop}, {@code deleteDrop}) are safe to perform while concurrent
+/// (`updateDrop`, `deleteDrop`) are safe to perform while concurrent
 /// readers iterate over the list.
 public class DropManager implements DropCatalog {
     private static final String KEY_AMOUNT = "amount";
@@ -608,7 +608,7 @@ public class DropManager implements DropCatalog {
     ///
     /// @param player         the fishing player (permission + biome checks)
     /// @param biomeName      current biome key string
-    /// @param luckMultiplier from {@code MythicRodRewardRollEvent}, clamped to at least 0.01
+    /// @param luckMultiplier from `MythicRodRewardRollEvent`, clamped to at least 0.01
     public CustomDrop getRandomDrop(PlatformPlayer player, String biomeName, double luckMultiplier) {
         if (player == null || !player.isOnline()) {
             fine(() -> "Skipping reward roll because player is null or offline");
@@ -743,7 +743,7 @@ public class DropManager implements DropCatalog {
     /// Update an existing drop with new properties.
     ///
     /// Thread safe: the category list is a {@link CopyOnWriteArrayList}, so
-    /// {@code set()} is atomic and concurrent readers are unaffected.
+    /// `set()` is atomic and concurrent readers are unaffected.
     ///
     /// @param dropId     The drop identifier
     /// @param category   The category name
@@ -781,7 +781,7 @@ public class DropManager implements DropCatalog {
 
     /// Adds a drop to a category from a {@link EditableDropFields} value object.
     ///
-    /// Returns {@code null} when the category or fields are invalid.
+    /// Returns `null` when the category or fields are invalid.
     public CustomDrop addDrop(String category, EditableDropFields fields) {
         if (category == null || category.isBlank() || fields == null) {
             return null;
@@ -837,7 +837,7 @@ public class DropManager implements DropCatalog {
     /// drops with the same material. The GUI passes the live {@link CustomDrop}
     /// object it opened so only that row is replaced.
     ///
-    /// @return {@code true} when the selected drop was still present
+    /// @return `true` when the selected drop was still present
     public boolean updateDrop(CustomDrop targetDrop, String category, int weight, int amount,
                               String customName, List<String> lore, boolean glowing) {
         if (targetDrop == null) return false;
@@ -858,7 +858,7 @@ public class DropManager implements DropCatalog {
 
     /// Replaces the selected drop instance with the supplied {@link EditableDropFields}.
     ///
-    /// @return {@code true} when the target was still present and the new fields validated
+    /// @return `true` when the target was still present and the new fields validated
     public boolean updateDrop(CustomDrop targetDrop, String category, EditableDropFields fields) {
         if (!hasUpdatableArguments(targetDrop, category, fields)) return false;
         String normalizedIdentifier = normalizeEditedIdentifier(fields.identifier());
@@ -930,7 +930,7 @@ public class DropManager implements DropCatalog {
 
     /// Deletes the exact drop instance selected by the GUI.
     ///
-    /// @return {@code true} when the selected drop was still present
+    /// @return `true` when the selected drop was still present
     public boolean deleteDrop(CustomDrop targetDrop, String category) {
         if (targetDrop == null || category == null || category.isBlank()) {
             return false;

--- a/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/drops/DropSelector.java
+++ b/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/drops/DropSelector.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 /// Thread-safe drop selector using weighted random selection.
 ///
 /// Thread safety: All methods are stateless with respect to mutable shared data.
-/// {@code ThreadLocalRandom.current()} is called per-invocation (never stored as a field)
+/// `ThreadLocalRandom.current()` is called per-invocation (never stored as a field)
 /// to guarantee correct behaviour across Folia region threads.
 @RequiredArgsConstructor
 public class DropSelector {
@@ -46,7 +46,7 @@ public class DropSelector {
 
     /// Selects a drop with luck-modified weights.
     ///
-    /// A {@code luckMultiplier} &gt; 1.0 scales up the effective weight of drops
+    /// A `luckMultiplier` &gt; 1.0 scales up the effective weight of drops
     /// whose base weight is &le; 5 (rare / legendary tier), making them relatively
     /// more probable without touching common or uncommon weights. A multiplier
     /// of 1.0 reproduces identical behaviour to the no-luck overload.
@@ -100,7 +100,7 @@ public class DropSelector {
     ///
     /// @param drops     Full drop pool.
     /// @param player    Player being evaluated.
-    /// @param biomeName Current biome key, or {@code null} if unavailable.
+    /// @param biomeName Current biome key, or `null` if unavailable.
     /// @return Immutable snapshot of eligible drops.
     public List<CustomDrop> getEligibleDrops(List<CustomDrop> drops, PlatformPlayer player, String biomeName) {
         if (drops == null || drops.isEmpty()) {
@@ -165,12 +165,12 @@ public class DropSelector {
     /// weights. It still builds short-lived arrays for each selection because
     /// the eligible set depends on player, biome and luck context.
     ///
-    /// Thread safety: {@code ThreadLocalRandom.current()} is called per
+    /// Thread safety: `ThreadLocalRandom.current()` is called per
     /// invocation so each Folia region thread uses its own random source.
     ///
     /// @param drops list of eligible drops
     /// @param luckMultiplier multiplier applied to rare drop weights
-    /// @return the selected drop, or {@code null} if all weights are zero
+    /// @return the selected drop, or `null` if all weights are zero
     private CustomDrop selectWeightedRandomOptimized(List<CustomDrop> drops, double luckMultiplier) {
         final int n = drops.size();
 

--- a/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/metrics/StatisticsManager.java
+++ b/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/metrics/StatisticsManager.java
@@ -32,20 +32,18 @@ import io.xcutiboo.mythicrod.stats.PlayerStats;
 
 /// Manages in-memory player fishing statistics with Caffeine TTL-bounded caching.
 ///
-/// <h2>Thread Safety</h2>
-/// <ul>
-///   <li>The active-players cache uses Caffeine and is safe for concurrent access.</li>
-///   <li>The dirty set uses {@link ConcurrentHashMap} as a set.</li>
-///   <li>{@link #saveAll()} is intended to be called from the async scheduler.</li>
-///   <li>{@link #getStats(UUID)} and {@link #recordCatch} may be called from
-///       any entity region thread.</li>
-/// </ul>
+/// ## Thread Safety
+///   - The active-players cache uses Caffeine and is safe for concurrent access.
+///   - The dirty set uses {@link ConcurrentHashMap} as a set.
+///   - {@link #saveAll()} is intended to be called from the async scheduler.
+///   - {@link #getStats(UUID)} and {@link #recordCatch} may be called from
+///       any entity region thread.
 ///
-/// <h2>Cache Design</h2>
+/// ## Cache Design
 /// Stats for online players are kept indefinitely while they are active.
 /// After login/access, entries expire from the cache after
 /// {@value #EXPIRE_AFTER_ACCESS_MINUTES} minutes of no access.
-/// This prevents {@code OutOfMemoryError} from unbounded accumulation.
+/// This prevents `OutOfMemoryError` from unbounded accumulation.
 public final class StatisticsManager {
 
     private static final int EXPIRE_AFTER_ACCESS_MINUTES = 30;
@@ -106,11 +104,11 @@ public final class StatisticsManager {
     }
 
     /// Path to the statistics YAML file inside the plugin data folder.
-    /// All player stats are stored here under {@code players.<uuid>.*}.
+    /// All player stats are stored here under `players.<uuid>.*`.
     private static final String STATS_FILENAME = "statistics.yml";
 
     /// Live reference to the statistics YAML configuration.
-    /// Guarded by {@code this} for write access; readers see either the old
+    /// Guarded by `this` for write access; readers see either the old
     /// reference or the new one swapped during reload, never a half-built object.
     @SuppressWarnings("java:S3077")
     private volatile PlatformConfiguration statsConfig;
@@ -141,7 +139,7 @@ public final class StatisticsManager {
         return totalCatchesGlobal.get();
     }
 
-    /// Returns the top {@code limit} players by total catches.
+    /// Returns the top `limit` players by total catches.
     /// Used by GUI menus that do not have async context.
     ///
     /// @param limit Max entries to return.
@@ -173,14 +171,14 @@ public final class StatisticsManager {
         });
     }
 
-    /// Returns the {@link PlayerStats} for the given UUID, or {@code null}
+    /// Returns the {@link PlayerStats} for the given UUID, or `null`
     /// if no entry has been created for this player yet.
     ///
     /// Unlike {@link #getOrCreate}, this does not create a new entry.
     /// Used by the API layer for read-only queries.
     ///
     /// @param uuid Player UUID.
-    /// @return Existing stats, or {@code null}.
+    /// @return Existing stats, or `null`.
     @Nullable
     public PlayerStats getStats(@NotNull UUID uuid) {
         PlayerStats cachedStats = statsCache.getIfPresent(uuid);
@@ -238,7 +236,7 @@ public final class StatisticsManager {
     /// the next persistence flush wipes the on-disk row.
     ///
     /// @param uuid Player UUID.
-    /// @return {@code true} if a stats entry existed to reset; {@code false} when
+    /// @return `true` if a stats entry existed to reset; `false` when
     ///         no in-memory or on-disk entry was present.
     public boolean resetStats(@NotNull UUID uuid) {
         PlayerStats inMemory = statsCache.getIfPresent(uuid);
@@ -332,10 +330,10 @@ public final class StatisticsManager {
         statsCache.invalidate(uuid);
     }
 
-    /// Persists a single player's stats to the {@code statistics.yml} file.
+    /// Persists a single player's stats to the `statistics.yml` file.
     ///
     /// Must be called from an async thread, never from the main server thread.
-    /// All writes are guarded by a {@code synchronized} block on {@code this} so
+    /// All writes are guarded by a `synchronized` block on `this` so
     /// concurrent saves from the Caffeine eviction listener don't corrupt the file.
     private boolean persistStats(@NotNull UUID uuid, @NotNull PlayerStats stats) {
         try {
@@ -461,7 +459,7 @@ public final class StatisticsManager {
         return persistedStats;
     }
 
-    /// Loads (or creates) the {@code statistics.yml} config from disk.
+    /// Loads (or creates) the `statistics.yml` config from disk.
     private @NotNull PlatformConfiguration loadStatsConfig() {
         File statsFile = new File(runtime.getDataFolder(), STATS_FILENAME);
         if (!runtime.getDataFolder().exists()) {

--- a/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/stats/PlayerStats.java
+++ b/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/stats/PlayerStats.java
@@ -54,7 +54,7 @@ public final class PlayerStats {
     public int getAdvancedRodUses()  { return advancedRodUses.get(); }
     public int getLegendaryRodUses() { return legendaryRodUses.get(); }
 
-    /// Returns the epoch-millisecond timestamp of the last catch, or {@code 0} if never.
+    /// Returns the epoch-millisecond timestamp of the last catch, or `0` if never.
     public long getLastFished()      { return lastFished.get(); }
 
     /// Returns non-zero catch counts by rarity tier, ordered from rarest to common.

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPI.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPI.java
@@ -487,7 +487,7 @@ public class PaperMythicRodAPI implements MythicRodAPI {
     }
 
     /// Synchronous snapshot for the given player, suitable for event handlers
-    /// already running on the player's owner thread. Returns {@code null} when
+    /// already running on the player's owner thread. Returns `null` when
     /// no in-memory or on-disk entry exists.
     @Nullable
     public PlayerStatSnapshot snapshotFor(@NotNull UUID playerId) {

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
@@ -69,6 +69,19 @@ public class BrigadierCommandManager {
     private static final String KEY_LIMIT = "limit";
     private static final String KEY_CATEGORY = "category";
     private static final String KEY_DROPS = "drops";
+    private static final String ARG_IDENTIFIER = "identifier";
+    private static final String ARG_WEIGHT = "weight";
+    private static final String ARG_AMOUNT = "amount";
+    private static final String ARG_FIELD = "field";
+    private static final String ARG_VALUE = "value";
+    private static final String ARG_BIOME = "biome";
+    private static final String ARG_LOCALE = "locale";
+    private static final String ARG_STATUS = "status";
+    private static final String ARG_CATEGORIES = "categories";
+    private static final String TIER_ADVANCED = "advanced";
+    private static final String TR_GENERAL_ENABLED = "general.enabled";
+    private static final String TR_GENERAL_DISABLED = "general.disabled";
+    private static final String TR_DROP_NOT_FOUND = "command.drop.not-found";
     private static final String TR_GENERAL_ERROR = "general.error";
     private static final String TR_PLAYER_ONLY = "general.player_only";
     private static final String KEY_ERROR = "error";
@@ -187,7 +200,7 @@ public class BrigadierCommandManager {
                 .executes(this::executeDrops)
                 .then(Commands.literal("preview")
                     .requires(source -> source.getSender().hasPermission(PermissionNodes.ADMIN_DEBUG))
-                    .then(Commands.argument("biome", StringArgumentType.greedyString())
+                    .then(Commands.argument(ARG_BIOME, StringArgumentType.greedyString())
                         .suggests(this::suggestBiomes)
                         .executes(this::executeDropsPreview)))
                 .then(Commands.argument(KEY_CATEGORY, StringArgumentType.word())
@@ -198,27 +211,27 @@ public class BrigadierCommandManager {
                 .then(Commands.literal("add")
                     .then(Commands.argument(KEY_CATEGORY, StringArgumentType.word())
                         .suggests(this::suggestDropCategories)
-                        .then(Commands.argument("identifier", StringArgumentType.string())
-                            .then(Commands.argument("weight", IntegerArgumentType.integer(1, 10000))
-                                .then(Commands.argument("amount", IntegerArgumentType.integer(1, 64))
+                        .then(Commands.argument(ARG_IDENTIFIER, StringArgumentType.string())
+                            .then(Commands.argument(ARG_WEIGHT, IntegerArgumentType.integer(1, 10000))
+                                .then(Commands.argument(ARG_AMOUNT, IntegerArgumentType.integer(1, 64))
                                     .executes(this::executeDropAdd))))))
                 .then(Commands.literal("remove")
                     .then(Commands.argument(KEY_CATEGORY, StringArgumentType.word())
                         .suggests(this::suggestDropCategories)
-                        .then(Commands.argument("identifier", StringArgumentType.string())
+                        .then(Commands.argument(ARG_IDENTIFIER, StringArgumentType.string())
                             .executes(this::executeDropRemove))))
                 .then(Commands.literal("set")
                     .then(Commands.argument(KEY_CATEGORY, StringArgumentType.word())
                         .suggests(this::suggestDropCategories)
-                        .then(Commands.argument("identifier", StringArgumentType.string())
-                            .then(Commands.argument("field", StringArgumentType.word())
+                        .then(Commands.argument(ARG_IDENTIFIER, StringArgumentType.string())
+                            .then(Commands.argument(ARG_FIELD, StringArgumentType.word())
                                 .suggests(this::suggestDropFields)
-                                .then(Commands.argument("value", StringArgumentType.greedyString())
+                                .then(Commands.argument(ARG_VALUE, StringArgumentType.greedyString())
                                     .executes(this::executeDropSet)))))))
             .then(Commands.literal("debug")
                 .requires(source -> source.getSender().hasPermission(PermissionNodes.ADMIN_DEBUG))
                 .executes(this::executeDebug))
-            .then(Commands.literal("status")
+            .then(Commands.literal(ARG_STATUS)
                 .requires(source -> source.getSender().hasPermission(PermissionNodes.ADMIN_DEBUG))
                 .executes(this::executeStatus))
             .then(Commands.literal("validate")
@@ -227,7 +240,7 @@ public class BrigadierCommandManager {
             .then(Commands.literal("testroll")
                 .requires(source -> source.getSender().hasPermission(PermissionNodes.ADMIN_DEBUG))
                 .executes(this::executeTestRoll)
-                .then(Commands.argument("biome", StringArgumentType.string())
+                .then(Commands.argument(ARG_BIOME, StringArgumentType.string())
                     .suggests(this::suggestBiomes)
                     .executes(this::executeTestRoll)
                     .then(Commands.argument(KEY_COUNT, IntegerArgumentType.integer(1, 10000))
@@ -319,7 +332,7 @@ public class BrigadierCommandManager {
                     .suggests(this::suggestRewardDeliveryModes)
                     .executes(this::executeDeliveryModeConfig)))
             .then(Commands.literal("language")
-                .then(Commands.argument("locale", StringArgumentType.word())
+                .then(Commands.argument(ARG_LOCALE, StringArgumentType.word())
                     .suggests(this::suggestAvailableLanguages)
                     .executes(this::executeLanguageConfig)))
             .then(Commands.literal("stats-save-interval")
@@ -419,8 +432,8 @@ public class BrigadierCommandManager {
 
     private ItemStack buildRodForTier(String tier) {
         return switch (tier.toLowerCase(Locale.ROOT)) {
-            case "basic" -> rodFactory.createBasicRod();
-            case "advanced" -> rodFactory.createAdvancedRod();
+            case TIER_BASIC -> rodFactory.createBasicRod();
+            case TIER_ADVANCED -> rodFactory.createAdvancedRod();
             case TIER_LEGENDARY -> rodFactory.createLegendaryRod();
             default -> null;
         };
@@ -527,12 +540,12 @@ public class BrigadierCommandManager {
         sendMessage(sender, tr(sender, "command.config.line",
             Map.of(
                 "setting", tr(sender, settingKey),
-                "value", value
+                ARG_VALUE, value
             )));
     }
 
     private String configStatus(CommandSender sender, boolean enabled) {
-        return tr(sender, enabled ? "general.enabled" : "general.disabled");
+        return tr(sender, enabled ? TR_GENERAL_ENABLED : TR_GENERAL_DISABLED);
     }
 
     private int executeBooleanConfig(
@@ -554,7 +567,7 @@ public class BrigadierCommandManager {
             sendMessage(sender, tr(sender, "command.config.boolean-set",
                 Map.of(
                     "setting", tr(sender, settingKey),
-                    "value", configStatus(sender, newValue)
+                    ARG_VALUE, configStatus(sender, newValue)
                 )));
             playSuccessSound(sender);
             return Command.SINGLE_SUCCESS;
@@ -608,13 +621,13 @@ public class BrigadierCommandManager {
         CommandSender sender = context.getSource().getSender();
         ConfigManager config = plugin.getConfigManager();
         String previousLocale = config.getLanguage();
-        String requested = StringArgumentType.getString(context, "locale");
+        String requested = StringArgumentType.getString(context, ARG_LOCALE);
         List<String> available = plugin.getLanguageManager().getAvailableLanguages();
 
         if (!available.contains(requested) || !config.setLanguage(requested)) {
             sendMessage(sender, tr(sender, "command.config.invalid-language",
                 Map.of(
-                    "locale", requested,
+                    ARG_LOCALE, requested,
                     "available", String.join(", ", available)
                 )));
             playErrorSound(sender);
@@ -631,13 +644,13 @@ public class BrigadierCommandManager {
                 plugin.getGUIManager().invalidateOpenMenusForReload();
             }
             sendMessage(sender, tr(sender, "command.config.language-set",
-                Map.of("locale", requested)));
+                Map.of(ARG_LOCALE, requested)));
             playSuccessSound(sender);
             return Command.SINGLE_SUCCESS;
         } catch (IOException | RuntimeException e) {
             config.setLanguage(previousLocale);
-            sendMessage(sender, tr(sender, "command.config.save-failed",
-                Map.of("error", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName())));
+            sendMessage(sender, tr(sender, TR_CONFIG_SAVE_FAILED,
+                Map.of(KEY_ERROR, e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName())));
             playErrorSound(sender);
             plugin.getLogger().log(Level.SEVERE, "Failed to update language", e);
             return 0;
@@ -1073,7 +1086,7 @@ public class BrigadierCommandManager {
         sendMessage(sender, tr(sender, "drops.category-not-found",
             Map.of(KEY_CATEGORY, category)));
         sendMessage(sender, tr(sender, "drops.available-categories",
-            Map.of("categories", String.join(", ", sortedDropCategoryIds()))));
+            Map.of(ARG_CATEGORIES, String.join(", ", sortedDropCategoryIds()))));
         sendMessage(sender, tr(sender, "drops.category-help"));
     }
 
@@ -1095,8 +1108,8 @@ public class BrigadierCommandManager {
             sendMessage(sender, tr(sender, "drops.drop-entry",
                 Map.of(
                     "name", name,
-                    "weight", weight,
-                    "amount", String.valueOf(drop.getAmount())
+                    ARG_WEIGHT, weight,
+                    ARG_AMOUNT, String.valueOf(drop.getAmount())
                 )));
         }
     }
@@ -1135,8 +1148,8 @@ public class BrigadierCommandManager {
         @SuppressWarnings("unused") CommandContext<CommandSourceStack> context,
         SuggestionsBuilder builder
     ) {
-        builder.suggest("basic");
-        builder.suggest("advanced");
+        builder.suggest(TIER_BASIC);
+        builder.suggest(TIER_ADVANCED);
         builder.suggest(TIER_LEGENDARY);
         return builder.buildFuture();
     }
@@ -1544,7 +1557,7 @@ public class BrigadierCommandManager {
             Player player = requirePlayer(sender);
             if (player == null) return 0;
 
-            String biomeArg = optionalStringArg(context, "biome");
+            String biomeArg = optionalStringArg(context, ARG_BIOME);
             int count = Math.clamp(optionalIntArg(context, KEY_COUNT, 100), 1, 10000);
             String biome = resolveTestRollBiome(player, biomeArg);
 
@@ -1604,7 +1617,7 @@ public class BrigadierCommandManager {
         @SuppressWarnings("unused") CommandContext<CommandSourceStack> context,
         SuggestionsBuilder builder
     ) {
-        for (String f : List.of("weight", "amount", "permission", "glow", "name")) {
+        for (String f : List.of(ARG_WEIGHT, ARG_AMOUNT, "permission", "glow", "name")) {
             builder.suggest(f);
         }
         return builder.buildFuture();
@@ -1614,9 +1627,9 @@ public class BrigadierCommandManager {
         CommandSender sender = context.getSource().getSender();
         try {
             String category = StringArgumentType.getString(context, KEY_CATEGORY).toLowerCase(Locale.ROOT);
-            String identifier = StringArgumentType.getString(context, "identifier").trim();
-            int weight = IntegerArgumentType.getInteger(context, "weight");
-            int amount = IntegerArgumentType.getInteger(context, "amount");
+            String identifier = StringArgumentType.getString(context, ARG_IDENTIFIER).trim();
+            int weight = IntegerArgumentType.getInteger(context, ARG_WEIGHT);
+            int amount = IntegerArgumentType.getInteger(context, ARG_AMOUNT);
 
             io.xcutiboo.mythicrod.drops.EditableDropFields fields =
                 new io.xcutiboo.mythicrod.drops.EditableDropFields(
@@ -1626,13 +1639,13 @@ public class BrigadierCommandManager {
             CustomDrop drop = plugin.getDropManager().addDrop(category, fields);
             if (drop == null) {
                 sendMessage(sender, tr(sender, "command.drop.invalid",
-                    Map.of("identifier", identifier)));
+                    Map.of(ARG_IDENTIFIER, identifier)));
                 playErrorSound(sender);
                 return 0;
             }
             plugin.getDropManager().saveDrops();
             sendMessage(sender, tr(sender, "command.drop.added",
-                Map.of("identifier", identifier, "category", category)));
+                Map.of(ARG_IDENTIFIER, identifier, KEY_CATEGORY, category)));
             playSuccessSound(sender);
             return Command.SINGLE_SUCCESS;
         } catch (RuntimeException e) {
@@ -1647,24 +1660,24 @@ public class BrigadierCommandManager {
         CommandSender sender = context.getSource().getSender();
         try {
             String category = StringArgumentType.getString(context, KEY_CATEGORY).toLowerCase(Locale.ROOT);
-            String identifier = StringArgumentType.getString(context, "identifier").trim();
+            String identifier = StringArgumentType.getString(context, ARG_IDENTIFIER).trim();
             CustomDrop target = findDropInCategory(category, identifier);
             if (target == null) {
-                sendMessage(sender, tr(sender, "command.drop.not-found",
-                    Map.of("identifier", identifier, "category", category)));
+                sendMessage(sender, tr(sender, TR_DROP_NOT_FOUND,
+                    Map.of(ARG_IDENTIFIER, identifier, KEY_CATEGORY, category)));
                 playErrorSound(sender);
                 return 0;
             }
             boolean removed = plugin.getDropManager().deleteDrop(target, category);
             if (!removed) {
-                sendMessage(sender, tr(sender, "command.drop.not-found",
-                    Map.of("identifier", identifier, "category", category)));
+                sendMessage(sender, tr(sender, TR_DROP_NOT_FOUND,
+                    Map.of(ARG_IDENTIFIER, identifier, KEY_CATEGORY, category)));
                 playErrorSound(sender);
                 return 0;
             }
             plugin.getDropManager().saveDrops();
             sendMessage(sender, tr(sender, "command.drop.removed",
-                Map.of("identifier", identifier, "category", category)));
+                Map.of(ARG_IDENTIFIER, identifier, KEY_CATEGORY, category)));
             playSuccessSound(sender);
             return Command.SINGLE_SUCCESS;
         } catch (RuntimeException e) {
@@ -1679,14 +1692,14 @@ public class BrigadierCommandManager {
         CommandSender sender = context.getSource().getSender();
         try {
             String category = StringArgumentType.getString(context, KEY_CATEGORY).toLowerCase(Locale.ROOT);
-            String identifier = StringArgumentType.getString(context, "identifier").trim();
-            String field = StringArgumentType.getString(context, "field").toLowerCase(Locale.ROOT);
-            String value = StringArgumentType.getString(context, "value");
+            String identifier = StringArgumentType.getString(context, ARG_IDENTIFIER).trim();
+            String field = StringArgumentType.getString(context, ARG_FIELD).toLowerCase(Locale.ROOT);
+            String value = StringArgumentType.getString(context, ARG_VALUE);
 
             CustomDrop target = findDropInCategory(category, identifier);
             if (target == null) {
-                sendMessage(sender, tr(sender, "command.drop.not-found",
-                    Map.of("identifier", identifier, "category", category)));
+                sendMessage(sender, tr(sender, TR_DROP_NOT_FOUND,
+                    Map.of(ARG_IDENTIFIER, identifier, KEY_CATEGORY, category)));
                 playErrorSound(sender);
                 return 0;
             }
@@ -1699,21 +1712,21 @@ public class BrigadierCommandManager {
 
             try {
                 switch (field) {
-                    case "weight" -> weight = Integer.parseInt(value.trim());
-                    case "amount" -> amount = Integer.parseInt(value.trim());
+                    case ARG_WEIGHT -> weight = Integer.parseInt(value.trim());
+                    case ARG_AMOUNT -> amount = Integer.parseInt(value.trim());
                     case "name" -> customName = value;
                     case "permission" -> permission = value.isBlank() ? null : value.trim();
                     case "glow" -> glow = Boolean.parseBoolean(value.trim());
                     default -> {
                         sendMessage(sender, tr(sender, "command.drop.unknown-field",
-                            Map.of("field", field)));
+                            Map.of(ARG_FIELD, field)));
                         playErrorSound(sender);
                         return 0;
                     }
                 }
             } catch (NumberFormatException _) {
                 sendMessage(sender, tr(sender, "command.drop.bad-value",
-                    Map.of("field", field, "value", value)));
+                    Map.of(ARG_FIELD, field, ARG_VALUE, value)));
                 playErrorSound(sender);
                 return 0;
             }
@@ -1727,14 +1740,14 @@ public class BrigadierCommandManager {
                 );
             boolean updated = plugin.getDropManager().updateDrop(target, category, next);
             if (!updated) {
-                sendMessage(sender, tr(sender, "command.drop.not-found",
-                    Map.of("identifier", identifier, "category", category)));
+                sendMessage(sender, tr(sender, TR_DROP_NOT_FOUND,
+                    Map.of(ARG_IDENTIFIER, identifier, KEY_CATEGORY, category)));
                 playErrorSound(sender);
                 return 0;
             }
             plugin.getDropManager().saveDrops();
             sendMessage(sender, tr(sender, "command.drop.updated",
-                Map.of("identifier", identifier, "field", field, "value", value)));
+                Map.of(ARG_IDENTIFIER, identifier, ARG_FIELD, field, ARG_VALUE, value)));
             playSuccessSound(sender);
             return Command.SINGLE_SUCCESS;
         } catch (RuntimeException e) {
@@ -1762,7 +1775,7 @@ public class BrigadierCommandManager {
             String tier = StringArgumentType.getString(context, "tier").toLowerCase(Locale.ROOT);
             String permission = switch (tier) {
                 case TIER_BASIC -> PermissionNodes.GUI;
-                case "advanced" -> PermissionNodes.ROD_ADVANCED;
+                case TIER_ADVANCED -> PermissionNodes.ROD_ADVANCED;
                 case TIER_LEGENDARY -> PermissionNodes.ROD_LEGENDARY;
                 default -> null;
             };
@@ -1904,19 +1917,19 @@ public class BrigadierCommandManager {
     private int executeDropsPreview(CommandContext<CommandSourceStack> context) {
         CommandSender sender = context.getSource().getSender();
         try {
-            String biome = StringArgumentType.getString(context, "biome").trim();
+            String biome = StringArgumentType.getString(context, ARG_BIOME).trim();
             NamespacedKey biomeKey = parseRegistryKey(biome);
             if (biomeKey == null
                     || RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME).get(biomeKey) == null) {
                 sendMessage(sender, tr(sender, "command.drops-preview.invalid-biome",
-                    Map.of("biome", biome)));
+                    Map.of(ARG_BIOME, biome)));
                 playErrorSound(sender);
                 return 0;
             }
             String biomeId = biomeKey.asString();
 
             sendMessage(sender, tr(sender, "command.drops-preview.header",
-                Map.of("biome", biomeId)));
+                Map.of(ARG_BIOME, biomeId)));
 
             int rows = 0;
             long totalWeight = 0L;
@@ -1949,15 +1962,15 @@ public class BrigadierCommandManager {
             for (EligibleDrop entry : eligible) {
                 if (rows++ >= 12) {
                     sendMessage(sender, tr(sender, "command.drops-preview.truncated",
-                        Map.of("count", String.valueOf(eligible.size() - 12))));
+                        Map.of(KEY_COUNT, String.valueOf(eligible.size() - 12))));
                     break;
                 }
                 double share = totalWeight == 0 ? 0.0 : (entry.drop().getWeight() * 100.0 / totalWeight);
                 sendMessage(sender, tr(sender, "command.drops-preview.row",
                     Map.of(
-                        "category", entry.category(),
-                        "identifier", entry.drop().getIdentifier(),
-                        "weight", String.valueOf(entry.drop().getWeight()),
+                        KEY_CATEGORY, entry.category(),
+                        ARG_IDENTIFIER, entry.drop().getIdentifier(),
+                        ARG_WEIGHT, String.valueOf(entry.drop().getWeight()),
                         "share", String.format(Locale.ROOT, "%.1f", share)
                     )));
             }
@@ -1966,8 +1979,8 @@ public class BrigadierCommandManager {
             } else {
                 sendMessage(sender, tr(sender, "command.drops-preview.footer",
                     Map.of(
-                        "count", String.valueOf(eligible.size()),
-                        "weight", String.valueOf(totalWeight))));
+                        KEY_COUNT, String.valueOf(eligible.size()),
+                        ARG_WEIGHT, String.valueOf(totalWeight))));
             }
             playSuccessSound(sender);
             return Command.SINGLE_SUCCESS;
@@ -2015,15 +2028,15 @@ public class BrigadierCommandManager {
                 Map.of("mode", mode, "minecraft", paperVersion)));
             sendMessage(sender, tr(sender, "command.status.drops",
                 Map.of(
-                    "categories", String.valueOf(categoryCount),
-                    "drops", String.valueOf(dropCount))));
+                    ARG_CATEGORIES, String.valueOf(categoryCount),
+                    KEY_DROPS, String.valueOf(dropCount))));
             sendMessage(sender, tr(sender, "command.status.language",
                 Map.of(
                     "active", activeLocale,
                     "loaded", String.valueOf(locales.size()),
                     "list", String.join(", ", locales))));
             sendMessage(sender, tr(sender, "command.status.nexo",
-                Map.of("status", tr(sender, nexoOn ? "general.enabled" : "general.disabled"))));
+                Map.of(ARG_STATUS, tr(sender, nexoOn ? TR_GENERAL_ENABLED : TR_GENERAL_DISABLED))));
             sendMessage(sender, tr(sender, "command.status.stats",
                 Map.of("players", String.valueOf(trackedPlayers))));
             return Command.SINGLE_SUCCESS;
@@ -2055,13 +2068,13 @@ public class BrigadierCommandManager {
                 : 0L;
             sendMessage(sender, tr(sender, "command.debug.runtime",
                 Map.of(
-                    "categories", String.valueOf(categoryCount),
+                    ARG_CATEGORIES, String.valueOf(categoryCount),
                     KEY_DROPS, String.valueOf(dropCount),
                     "players", String.valueOf(trackedPlayers),
                     "catches", String.valueOf(totalCatches)
                 )));
             sendMessage(sender, tr(sender, "command.debug.folia-support",
-                Map.of("status", tr(sender, plugin.isFoliaRuntime() ? "general.enabled" : "general.disabled"))));
+                Map.of(ARG_STATUS, tr(sender, plugin.isFoliaRuntime() ? TR_GENERAL_ENABLED : TR_GENERAL_DISABLED))));
 
             return Command.SINGLE_SUCCESS;
         } catch (Exception e) {

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/commands/BrigadierCommandManager.java
@@ -1943,18 +1943,10 @@ public class BrigadierCommandManager {
                     && plugin.getConfigManager().usePermissions();
             for (Map.Entry<String, List<CustomDrop>> entry : categories.entrySet()) {
                 for (CustomDrop drop : entry.getValue()) {
-                    List<String> biomes = drop.getBiomes();
-                    if (biomes != null && !biomes.isEmpty() && !biomes.contains(biomeId)) {
-                        continue;
+                    if (isEligibleForPreview(sender, drop, biomeId, filterByPermission)) {
+                        eligible.add(new EligibleDrop(entry.getKey(), drop));
+                        totalWeight += Math.max(0, drop.getWeight());
                     }
-                    if (filterByPermission) {
-                        String required = drop.getPermission();
-                        if (required != null && !required.isEmpty() && !sender.hasPermission(required)) {
-                            continue;
-                        }
-                    }
-                    eligible.add(new EligibleDrop(entry.getKey(), drop));
-                    totalWeight += Math.max(0, drop.getWeight());
                 }
             }
             eligible.sort(Comparator.comparingInt((EligibleDrop e) -> e.drop().getWeight()).reversed());
@@ -1993,6 +1985,24 @@ public class BrigadierCommandManager {
     }
 
     private record EligibleDrop(String category, CustomDrop drop) {}
+
+    private static boolean isEligibleForPreview(
+            CommandSender sender,
+            CustomDrop drop,
+            String biomeId,
+            boolean filterByPermission) {
+        List<String> biomes = drop.getBiomes();
+        if (biomes != null && !biomes.isEmpty() && !biomes.contains(biomeId)) {
+            return false;
+        }
+        if (filterByPermission) {
+            String required = drop.getPermission();
+            if (required != null && !required.isEmpty() && !sender.hasPermission(required)) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     private int executeStatus(CommandContext<CommandSourceStack> context) {
         CommandSender sender = context.getSource().getSender();

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/events/MythicRodStatsUpdateEvent.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/events/MythicRodStatsUpdateEvent.java
@@ -47,7 +47,7 @@ public final class MythicRodStatsUpdateEvent extends Event {
         return playerId;
     }
 
-    /// Rarity tier that was incremented: one of {@code common}, {@code uncommon}, {@code rare}, {@code legendary}.
+    /// Rarity tier that was incremented: one of `common`, `uncommon`, `rare`, `legendary`.
     @NotNull
     public String getTier() {
         return tier;

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/fishing/FishingListener.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/fishing/FishingListener.java
@@ -413,7 +413,6 @@ public class FishingListener implements Listener {
         }
     }
 
-    @SuppressWarnings("unused")
     private Consumer<ScheduledTask> foliaTask(Runnable action) {
         return task -> action.run();
     }

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/EditDropMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/EditDropMenu.java
@@ -35,16 +35,15 @@ import io.xcutiboo.mythicrod.paper.util.StringFormatting;
 /// GUI menu for editing individual drop properties in-game.
 ///
 /// Context keys (set via {@link #setContext(Map)} before {@link #open()}):
-/// <ul>
-///   <li>{@code "drop"} - {@link CustomDrop} to edit (required)</li>
-///   <li>{@code "category"} - {@link String} category name (required)</li>
-/// </ul>
+///   - `"drop"` - {@link CustomDrop} to edit (required)
+///   - `"category"` - {@link String} category name (required)
 ///
 /// Usage:
-/// <pre>{@code
+///
+/// ```java
 /// plugin.getGUIManager().openMenu(player, "editdrop",
 ///     Map.of("drop", drop, "category", category));
-/// }</pre>
+/// ```
 public class EditDropMenu extends BaseMenu {
     private static final String CTX_AMOUNT = "amount";
 

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/LanguageSwitchMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/LanguageSwitchMenu.java
@@ -30,7 +30,7 @@ public class LanguageSwitchMenu extends BaseMenu {
         10, 11, 12, 14, 15, 16, 19, 20, 21, 23, 24, 25
     };
 
-    private static final String TR_LANG_PREFIX = TR_LANG_PREFIX;
+    private static final String TR_LANG_PREFIX = "gui.language.languages.";
 
     public LanguageSwitchMenu(MythicRod plugin, Player player) {
         super(plugin, player);

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/LanguageSwitchMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/LanguageSwitchMenu.java
@@ -30,6 +30,8 @@ public class LanguageSwitchMenu extends BaseMenu {
         10, 11, 12, 14, 15, 16, 19, 20, 21, 23, 24, 25
     };
 
+    private static final String TR_LANG_PREFIX = TR_LANG_PREFIX;
+
     public LanguageSwitchMenu(MythicRod plugin, Player player) {
         super(plugin, player);
     }
@@ -132,7 +134,7 @@ public class LanguageSwitchMenu extends BaseMenu {
     }
 
     private Component resolveDisplayName(String locale) {
-        String key = "gui.language.languages." + curatedKey(locale) + ".name";
+        String key = TR_LANG_PREFIX + curatedKey(locale) + ".name";
         String value = plugin.getLanguageManager().tr(key);
         if (value.equals(key)) {
             return Component.text(locale.toUpperCase(Locale.ROOT));
@@ -141,7 +143,7 @@ public class LanguageSwitchMenu extends BaseMenu {
     }
 
     private Component resolveDescription(String locale) {
-        String key = "gui.language.languages." + curatedKey(locale) + ".description";
+        String key = TR_LANG_PREFIX + curatedKey(locale) + ".description";
         String value = plugin.getLanguageManager().tr(key);
         if (value.equals(key)) {
             return Component.text(plugin.getLanguageManager().tr(
@@ -152,7 +154,7 @@ public class LanguageSwitchMenu extends BaseMenu {
     }
 
     private Component resolveRegion(String locale) {
-        String key = "gui.language.languages." + curatedKey(locale) + ".region";
+        String key = TR_LANG_PREFIX + curatedKey(locale) + ".region";
         String value = plugin.getLanguageManager().tr(key);
         if (value.equals(key)) {
             return Component.text(plugin.getLanguageManager().tr(

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/StatsMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/StatsMenu.java
@@ -22,7 +22,7 @@ import io.xcutiboo.mythicrod.stats.PlayerStats;
 /// for personal stats and falls back to a temporary zeroed view for first-time players,
 /// while using
 /// {@link io.xcutiboo.mythicrod.metrics.StatisticsManager#getTopFishers(int)}
-/// for the leaderboard (returns {@code List<PlayerStats>} sorted by totalCaught).
+/// for the leaderboard (returns `List<PlayerStats>` sorted by totalCaught).
 public class StatsMenu extends BaseMenu {
     private static final String CTX_COUNT = "count";
 

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/scheduler/FoliaSchedulerService.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/scheduler/FoliaSchedulerService.java
@@ -268,12 +268,10 @@ public class FoliaSchedulerService implements PlatformScheduler {
         return platformTask;
     }
 
-    @SuppressWarnings("unused")
     private Consumer<ScheduledTask> foliaTask(Runnable task) {
         return scheduledTask -> task.run();
     }
 
-    @SuppressWarnings("unused")
     private Consumer<ScheduledTask> foliaOneShot(AtomicReference<PaperTask> taskRef, Runnable task) {
         return scheduledTask -> runOneShot(taskRef, task);
     }

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/update/UpdateChecker.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/update/UpdateChecker.java
@@ -84,7 +84,7 @@ public final class UpdateChecker {
             } else {
                 log.debug("Update check: GitHub returned HTTP {} for the latest-release endpoint.", resp.statusCode());
             }
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
             Thread.currentThread().interrupt();
         } catch (RuntimeException | IOException e) {
             log.debug("Update check failed: {}", e.getMessage());
@@ -97,7 +97,7 @@ public final class UpdateChecker {
         }
         int[] cur = parse(currentVersion);
         int[] rem = parse(latest);
-        if (cur == null || rem == null) {
+        if (cur.length == 0 || rem.length == 0) {
             return !latest.equals(currentVersion);
         }
         for (int i = 0; i < cur.length; i++) {
@@ -109,7 +109,7 @@ public final class UpdateChecker {
 
     private static int[] parse(String version) {
         Matcher m = VERSION.matcher(version);
-        if (!m.find()) return null;
+        if (!m.find()) return new int[0];
         return new int[] {
             Integer.parseInt(m.group(1)),
             Integer.parseInt(m.group(2)),
@@ -128,7 +128,7 @@ public final class UpdateChecker {
                     () -> { if (!cancelled) runCheck(); },
                     INITIAL_DELAY_SECONDS * 20L,
                     REPEAT_INTERVAL_SECONDS * 20L);
-            } catch (UnsupportedOperationException folia) {
+            } catch (UnsupportedOperationException _) {
                 // Folia does not have a global Bukkit scheduler; fall back to the async scheduler.
                 plugin.getServer().getAsyncScheduler().runAtFixedRate(
                     plugin,

--- a/mythicrod-paper/src/test/java/io/xcutiboo/mythicrod/paper/internal/config/BundledLocaleParityTest.java
+++ b/mythicrod-paper/src/test/java/io/xcutiboo/mythicrod/paper/internal/config/BundledLocaleParityTest.java
@@ -20,6 +20,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /// Compile-time guard that every bundled locale matches `en_US.yml` in
@@ -87,7 +88,7 @@ class BundledLocaleParityTest {
     private static YamlConfiguration loadBundledLocale(String locale) {
         URL url = BundledLocaleParityTest.class.getClassLoader()
             .getResource("lang/" + locale + ".yml");
-        assertTrue(url != null, () -> "bundled locale not on test classpath: " + locale);
+        assertNotNull(url, () -> "bundled locale not on test classpath: " + locale);
         Path path = toPath(url);
         return YamlConfiguration.loadConfiguration(path.toFile());
     }
@@ -95,7 +96,7 @@ class BundledLocaleParityTest {
     private static Path toPath(URL url) {
         try {
             return Paths.get(url.toURI());
-        } catch (Exception exception) {
+        } catch (Exception _) {
             return new File(url.getFile()).toPath();
         }
     }


### PR DESCRIPTION
Second sweep on Sonar findings: S7467 unnamed patterns, S1168 empty array, S5785 assertNotNull, S135/cognitive-complexity helper extraction in drops-preview, S1452 wildcard rationale, S8544/S8541 pip hardening in pages workflow.

## Summary by Sourcery

Refine command handling, documentation, and workflows based on Sonar findings for improved readability, safety, and maintainability.

Bug Fixes:
- Improve robustness of version comparison when parsing release tags fails by falling back to a string comparison rather than returning null arrays.

Enhancements:
- Introduce shared constants and a helper method in Brigadier command handling to reduce duplication and cognitive complexity, especially in drops preview and status/debug outputs.
- Tighten version parsing and comparison logic in the update checker and modernize exception handling by using unused-parameter conventions instead of named variables.
- Polish Javadoc-style comments across API, metrics, drops, and GUI code to use consistent code formatting and clarify thread-safety and behavior contracts.
- Remove redundant suppression annotations and unused helper wrappers in scheduler and listener code, and add a documented wildcard type in the public API to avoid unnecessary defensive copies.

Build:
- Harden the documentation Pages workflow by pinning MkDocs-related Python dependencies to exact versions and installing only binary wheels for pip packages.

Documentation:
- Clarify GUI usage and context keys in the drop-editing menu and improve language menu translation key handling with a shared prefix constant.

Tests:
- Adjust locale resource-loading test to assert non-null URLs directly and simplify URL-to-path conversion error handling.