### PR TITLE
feat: mythic rod tier

### DIFF
--- a/docs/developer-api/rods.md
+++ b/docs/developer-api/rods.md
@@ -6,7 +6,7 @@ PersistentDataContainer keys:
 | Key | Type | Meaning |
 | --- | --- | --- |
 | `mythicrod:custom_rod` | byte (1) | This item is a MythicRod rod |
-| `mythicrod:rod_tier` | string | One of `basic`, `advanced`, `legendary` |
+| `mythicrod:rod_tier` | string | One of `basic`, `advanced`, `legendary`, `mythic` |
 
 The display name or lore is never used as identity. A survival player
 cannot rename a vanilla rod into a MythicRod rod.
@@ -23,8 +23,9 @@ PlatformItem rod = api.createRod("advanced").orElseThrow();
 player.getInventory().addItem(((PaperPlatformItem) rod).getItemStack());
 ```
 
-Valid tiers (case-insensitive): `basic`, `advanced`, `legendary`. An
-unknown tier returns a `Result.failure` rather than throwing.
+Valid tiers (case-insensitive): `basic`, `advanced`, `legendary`,
+`mythic`. An unknown tier returns a `Result.failure` rather than
+throwing.
 
 ### Manual rod creation (legacy path)
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -15,6 +15,7 @@
 | `mythicrod.drops.legendary` | `op` | Receive `legendary` drops |
 | `mythicrod.rod.advanced` | `op` | Use the advanced rod tier |
 | `mythicrod.rod.legendary` | `op` | Use the legendary rod tier |
+| `mythicrod.rod.mythic` | `op` | Use the mythic rod tier (top of the loot ladder) |
 | `mythicrod.admin.reload` | `op` | Reload runtime data |
 | `mythicrod.admin.give` | `op` | Give MythicRod items |
 | `mythicrod.admin.config` | `op` | Edit drops, config, run `stats reset` |

--- a/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/MythicRodAPI.java
+++ b/mythicrod-api/src/main/java/io/xcutiboo/mythicrod/api/MythicRodAPI.java
@@ -152,14 +152,16 @@ public interface MythicRodAPI {
     /// MythicRod's PDC marker and tier metadata so the catch listener and
     /// statistics pipeline pick it up.
     ///
-    /// Valid tier names are `"basic"`, `"advanced"`, and `"legendary"`, matched
-    /// case-insensitively. The rod's display name, lore, glow, and unbreakable
-    /// flag follow MythicRod's built-in presets for that tier.
+    /// Valid tier names are `"basic"`, `"advanced"`, `"legendary"`, and
+    /// `"mythic"`, matched case-insensitively. The rod's display name, lore,
+    /// glow, and unbreakable flag follow MythicRod's built-in presets for that
+    /// tier.
     ///
     /// Prefer this over building an `ItemStack` and writing PDC keys by hand:
     /// future internal changes to the rod marker stay invisible to the caller.
     ///
-    /// @param tier `"basic"`, `"advanced"`, or `"legendary"` (case-insensitive).
+    /// @param tier `"basic"`, `"advanced"`, `"legendary"`, or `"mythic"`
+    ///             (case-insensitive).
     /// @return success result with the tagged rod, or failure when the tier is
     ///         unknown.
     @ApiStatus.AvailableSince("2026.2.0")

--- a/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/config/ConfigManager.java
+++ b/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/config/ConfigManager.java
@@ -50,6 +50,7 @@ public class ConfigManager {
     private double basicRodLuckMultiplier = 1.0D;
     private double advancedRodLuckMultiplier = 1.25D;
     private double legendaryRodLuckMultiplier = 1.5D;
+    private double mythicRodLuckMultiplier = 2.0D;
     private int statsSaveInterval = 600;
     private String language = DEFAULT_LANGUAGE;
     private String profile = DEFAULT_PROFILE;
@@ -110,6 +111,7 @@ public class ConfigManager {
             basicRodLuckMultiplier = resolveRodLuckMultiplier("basic", 1.0D);
             advancedRodLuckMultiplier = resolveRodLuckMultiplier("advanced", 1.25D);
             legendaryRodLuckMultiplier = resolveRodLuckMultiplier("legendary", 1.5D);
+            mythicRodLuckMultiplier = resolveRodLuckMultiplier("mythic", 2.0D);
 
             prefix = config.getString("ui.prefix", DEFAULT_PREFIX);
             if (prefix == null || prefix.isEmpty()) {
@@ -198,6 +200,7 @@ public class ConfigManager {
         basicRodLuckMultiplier = 1.0D;
         advancedRodLuckMultiplier = 1.25D;
         legendaryRodLuckMultiplier = 1.5D;
+        mythicRodLuckMultiplier = 2.0D;
         language = DEFAULT_LANGUAGE;
         profile = DEFAULT_PROFILE;
         statsSaveInterval = 600;
@@ -288,6 +291,7 @@ public class ConfigManager {
         return switch (tier.trim().toLowerCase(Locale.ROOT)) {
             case "advanced" -> advancedRodLuckMultiplier;
             case "legendary" -> legendaryRodLuckMultiplier;
+            case "mythic" -> mythicRodLuckMultiplier;
             default -> basicRodLuckMultiplier;
         };
     }

--- a/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/constants/PermissionNodes.java
+++ b/mythicrod-common/src/main/java/io/xcutiboo/mythicrod/constants/PermissionNodes.java
@@ -24,4 +24,5 @@ public final class PermissionNodes {
 
     public static final String ROD_ADVANCED = "mythicrod.rod.advanced";
     public static final String ROD_LEGENDARY = "mythicrod.rod.legendary";
+    public static final String ROD_MYTHIC = "mythicrod.rod.mythic";
 }

--- a/mythicrod-common/src/main/resources/config.yml
+++ b/mythicrod-common/src/main/resources/config.yml
@@ -83,6 +83,10 @@ features:
       basic: 1.0
       advanced: 1.25
       legendary: 1.5
+      # Mythic rod tier - top-of-tier reward. Gate behind a permission node
+      # (mythicrod.rod.mythic) so it stays a sink for prestige progression
+      # rather than something every player holds.
+      mythic: 2.0
 
   permissions:
     # Require specific permissions for certain drops

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPI.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPI.java
@@ -157,10 +157,12 @@ public class PaperMythicRodAPI implements MythicRodAPI {
             case "basic" -> rodFactory.createBasicRod();
             case "advanced" -> rodFactory.createAdvancedRod();
             case "legendary" -> rodFactory.createLegendaryRod();
+            case "mythic" -> rodFactory.createMythicRod();
             default -> null;
         };
         if (rod == null) {
-            return Result.failure("Unknown rod tier '" + tier + "'. Valid tiers: basic, advanced, legendary.");
+            return Result.failure("Unknown rod tier '" + tier
+                + "'. Valid tiers: basic, advanced, legendary, mythic.");
         }
         return Result.success(new PaperItem(rod));
     }

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/fishing/FishingListener.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/fishing/FishingListener.java
@@ -58,6 +58,7 @@ public class FishingListener implements Listener {
     private static final String TIER_BASIC = "basic";
     private static final String TIER_ADVANCED = "advanced";
     private static final String TIER_LEGENDARY = "legendary";
+    private static final String TIER_MYTHIC = "mythic";
 
     private final MythicRod plugin;
     private final RodFactory rodFactory;
@@ -203,6 +204,7 @@ public class FishingListener implements Listener {
         return switch (normalizeRodTier(tier)) {
             case TIER_ADVANCED -> player != null && player.hasPermission(PermissionNodes.ROD_ADVANCED);
             case TIER_LEGENDARY -> player != null && player.hasPermission(PermissionNodes.ROD_LEGENDARY);
+            case TIER_MYTHIC -> player != null && player.hasPermission(PermissionNodes.ROD_MYTHIC);
             case TIER_BASIC -> true;
             default -> false;
         };

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/RodMenu.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/gui/menus/RodMenu.java
@@ -15,6 +15,7 @@ public class RodMenu extends BaseMenu {
     private static final String TIER_BASIC = "basic";
     private static final String TIER_ADVANCED = "advanced";
     private static final String TIER_LEGENDARY = "legendary";
+    private static final String TIER_MYTHIC = "mythic";
     private static final String CTX_MULTIPLIER = "multiplier";
     private static final String TR_MULTIPLIER = "gui.rod.multiplier";
     private static final String TR_ALREADY_SELECTED = "gui.rod.already_selected";
@@ -46,6 +47,7 @@ public class RodMenu extends BaseMenu {
         placeBasicTier(player, currentTier);
         placeAdvancedTier(player, currentTier);
         placeLegendaryTier(player, currentTier);
+        placeMythicTier(player, currentTier);
         placeVisualEffectsToggle(player, globalEffectsEnabled, reducedEffects);
         placeBackButton(player);
         placeCloseButton(player);
@@ -121,6 +123,26 @@ public class RodMenu extends BaseMenu {
             "gui.rod.legendary.label", "gui.rod.legendary.selected", "gui.rod.legendary.locked"));
     }
 
+    private void placeMythicTier(Player player, String currentTier) {
+        ItemStack mythicRod = new ItemBuilder(Material.FISHING_ROD)
+                .name(tr("gui.rod.mythic.name"))
+                .glow(currentTier.equals(TIER_MYTHIC))
+                .lore(
+                        tr("gui.rod.mythic.lore1"),
+                        "",
+                        tr("gui.rod.mythic.lore2"),
+                        tr(TR_MULTIPLIER, Map.of(CTX_MULTIPLIER, formatMultiplier(TIER_MYTHIC))),
+                        tr("gui.rod.mythic.lore3"),
+                        tr("gui.rod.mythic.lore4"),
+                        "",
+                        currentTier.equals(TIER_MYTHIC) ? tr("gui.rod.mythic.equipped") : tr("gui.rod.mythic.click")
+                )
+                .build();
+        setItem(16, mythicRod, () -> selectGatedTier(
+            player, currentTier, TIER_MYTHIC, PermissionNodes.ROD_MYTHIC,
+            "gui.rod.mythic.label", "gui.rod.mythic.selected", "gui.rod.mythic.locked"));
+    }
+
     private void selectGatedTier(Player player, String currentTier, String targetTier,
                                   String permission, String labelKey, String selectedKey, String lockedKey) {
         if (currentTier.equals(targetTier)) {
@@ -153,7 +175,7 @@ public class RodMenu extends BaseMenu {
                 )
                 .glow(globalEffectsEnabled && !reducedEffects)
                 .build();
-        setItem(16, visualEffects, () -> {
+        setItem(22, visualEffects, () -> {
             playClickSound();
             if (!globalEffectsEnabled) {
                 playErrorSound();

--- a/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/RodFactory.java
+++ b/mythicrod-paper/src/main/java/io/xcutiboo/mythicrod/paper/item/RodFactory.java
@@ -77,6 +77,25 @@ public class RodFactory {
         );
     }
 
+    public ItemStack createMythicRod() {
+        return createRod(
+            "mythic",
+            "<gradient:#FF55FF:#AA00AA:#FFAA00><bold>MythicRod</bold></gradient>",
+            new String[]{
+                "<gray>Prestige rod. Gate behind a",
+                "<gray>permission node, reward grinders.",
+                "",
+                "<gold>Tier: <gradient:#FF55FF:#FFAA00>Mythic</gradient>",
+                "<dark_gray>✦✦✦✦ " + formatMultiplier("mythic") + LORE_RARE_LUCK_SUFFIX,
+                "<dark_gray>✦✦✦✦ Requires mythic rod access",
+                "<dark_gray>✦✦✦✦ Top of the loot ladder",
+                "<dark_gray>✦✦✦✦ Unbreakable"
+            },
+            true,
+            true
+        );
+    }
+
     /// Creates a rod item and stores the MythicRod marker plus tier in its PDC.
     public ItemStack createRod(String tier, String name, String[] lore) {
         return createRod(tier, name, lore, false, false);

--- a/mythicrod-paper/src/main/resources/lang/en_US.yml
+++ b/mythicrod-paper/src/main/resources/lang/en_US.yml
@@ -51,7 +51,7 @@ command:
     locked: '<red>✗ <dark_red>You lack permission for tier <yellow>%tier%<dark_red>.'
   give:
     tier-missing: '<red>✗ <dark_red>Tier cannot be empty.'
-    invalid-tier: '<red>✗ <dark_red>Invalid tier <yellow>%tier%<dark_red>. Use <yellow>basic<dark_red>, <yellow>advanced<dark_red>, or <yellow>legendary<dark_red>.'
+    invalid-tier: '<red>✗ <dark_red>Invalid tier <yellow>%tier%<dark_red>. Use <yellow>basic<dark_red>, <yellow>advanced<dark_red>, <yellow>legendary<dark_red>, or <yellow>mythic<dark_red>.'
     rod-creation-failed: '<red>✗ <dark_red>Failed to create the requested MythicRod.'
     target-offline: '<red>✗ <dark_red>Player <yellow>%player%<dark_red> went offline.'
     inventory-full: '<red>✗ <dark_red>Player <yellow>%player%<dark_red> has no free inventory slot for this MythicRod.'
@@ -760,6 +760,17 @@ gui:
       click: '<yellow>▶ Click to make this your default'
       selected: '<green>✓ Default fishing tier set to Legendary. <dark_gray>Cast with a vanilla rod to use it.'
       locked: '<red>✗ You need permission to use the Legendary tier.'
+    mythic:
+      label: 'Mythic'
+      name: '<gradient:#FF55FF:#FFAA00><bold>Mythic Rod'
+      lore1: '<gray>Prestige tier - top of the loot ladder'
+      lore2: '<gray>Active when you cast with a vanilla rod'
+      lore3: '<dark_gray>Requires mythicrod.rod.mythic'
+      lore4: '<yellow>Gate this for endgame grinders only'
+      equipped: '<green>✓ Your default tier'
+      click: '<yellow>▶ Click to make this your default'
+      selected: '<green>✓ Default fishing tier set to Mythic. <dark_gray>Cast with a vanilla rod to use it.'
+      locked: '<red>✗ You need permission to use the Mythic tier.'
     effects:
       name: '<light_purple><bold>Visual Effects'
       lore1: '<gray>Controls personal particles for'

--- a/mythicrod-paper/src/main/resources/lang/ja_JP.yml
+++ b/mythicrod-paper/src/main/resources/lang/ja_JP.yml
@@ -51,7 +51,7 @@ command:
     locked: '<red>✗ <dark_red>ティア <yellow>%tier%<dark_red> を使用する権限がありません。'
   give:
     tier-missing: '<red>✗ <dark_red>ティアを空にはできません。'
-    invalid-tier: '<red>✗ <dark_red>無効なティア <yellow>%tier%<dark_red> です。<yellow>basic<dark_red>、<yellow>advanced<dark_red>、<yellow>legendary<dark_red> を使用してください。'
+    invalid-tier: '<red>✗ <dark_red>無効なティア <yellow>%tier%<dark_red> です。<yellow>basic<dark_red>、<yellow>advanced<dark_red>、<yellow>legendary<dark_red>、<yellow>mythic<dark_red> を使用してください。'
     rod-creation-failed: '<red>✗ <dark_red>指定された MythicRod を作成できませんでした。'
     target-offline: '<red>✗ <dark_red>プレイヤー <yellow>%player%<dark_red> はオフラインになりました。'
     inventory-full: '<red>✗ <dark_red>プレイヤー <yellow>%player%<dark_red> のインベントリに MythicRod を受け取る空き枠がありません。'
@@ -758,6 +758,17 @@ gui:
       click: '<yellow>▶ クリックしてデフォルトに設定'
       selected: '<green>✓ <gray>デフォルトの釣りティアを レジェンダリー に設定しました。<dark_gray>通常のロッドで釣ると適用されます。'
       locked: '<red>✗ <dark_red>レジェンダリーティアを使う権限がありません。'
+    mythic:
+      label: 'ミシック'
+      name: '<gradient:#FF55FF:#FFAA00><bold>ミシックロッド'
+      lore1: '<gray>プレステージティア - 最上位の釣果'
+      lore2: '<gray>通常のロッドでキャストするときに有効'
+      lore3: '<dark_gray>mythicrod.rod.mythic が必要'
+      lore4: '<yellow>エンドゲーム勢向けにゲートしてください'
+      equipped: '<green>✓ デフォルトティア'
+      click: '<yellow>▶ クリックしてデフォルトに設定'
+      selected: '<green>✓ <gray>デフォルトの釣りティアを ミシック に設定しました。<dark_gray>通常のロッドで釣ると適用されます。'
+      locked: '<red>✗ <dark_red>ミシックティアを使う権限がありません。'
     effects:
       name: '<light_purple><bold>表示演出'
       lore1: '<gray>メニューと釣果演出の'

--- a/mythicrod-paper/src/main/resources/paper-plugin.yml
+++ b/mythicrod-paper/src/main/resources/paper-plugin.yml
@@ -116,6 +116,7 @@ permissions:
     children:
       mythicrod.rod.advanced: true
       mythicrod.rod.legendary: true
+      mythicrod.rod.mythic: true
 
   mythicrod.rod.advanced:
     description: Use advanced rod tier
@@ -123,4 +124,8 @@ permissions:
 
   mythicrod.rod.legendary:
     description: Use legendary rod tier
+    default: op
+
+  mythicrod.rod.mythic:
+    description: Use mythic rod tier (top of the loot ladder)
     default: op

--- a/mythicrod-paper/src/test/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPICreateRodTest.java
+++ b/mythicrod-paper/src/test/java/io/xcutiboo/mythicrod/paper/api/PaperMythicRodAPICreateRodTest.java
@@ -27,19 +27,20 @@ class PaperMythicRodAPICreateRodTest {
         assertTrue(result.getError().contains("basic"));
         assertTrue(result.getError().contains("advanced"));
         assertTrue(result.getError().contains("legendary"));
+        assertTrue(result.getError().contains("mythic"));
     }
 
     @Test
-    void unknownTierIsCaseInsensitiveOnTheReportedInput() {
+    void unknownTierEchoesTheOriginalCasingInTheErrorMessage() {
         PaperMythicRodAPI api = new PaperMythicRodAPI(
             "test-version",
             java.util.logging.Logger.getAnonymousLogger(),
             null, null, null, null, null
         );
 
-        Result<PlatformItem> result = api.createRod("MYTHIC");
+        Result<PlatformItem> result = api.createRod("Diamond-Tier");
 
         assertFalse(result.isSuccess());
-        assertTrue(result.getError().contains("MYTHIC"));
+        assertTrue(result.getError().contains("Diamond-Tier"));
     }
 }


### PR DESCRIPTION
Adds a fourth rod tier above legendary. Permission `mythicrod.rod.mythic`, default luck multiplier 2.0, presets + locale + docs wired. Visuals toggle moved from slot 16 to slot 22 so the four rod buttons sit evenly in row 2.

## Summary by Sourcery

Add a new mythic fishing rod tier and wire it through gameplay, configuration, permissions, API, GUI, and documentation.

New Features:
- Introduce a mythic rod tier above legendary with its own preset item, lore, and GUI entry.
- Expose mythic rod creation via the public API and include it as a valid tier for rod factory and commands.
- Add a dedicated permission node for using the mythic rod tier and include it under the general rod permission group.

Enhancements:
- Make the GUI layout symmetrical by moving the visual effects toggle to accommodate four rod tier buttons.
- Extend configuration to support a configurable luck multiplier for the mythic tier with a default of 2.0.
- Update language files, API Javadoc, and developer documentation to describe the mythic tier and its semantics.

Documentation:
- Document the mythic rod tier and permission in the public developer and permissions docs.

Tests:
- Adjust API tests to cover the updated valid tier list and to verify error messages echo the original casing of unknown tiers.